### PR TITLE
chore: rename plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-# Pressbooks Multi Institution
-
+# Pressbooks Shared Network
 **Contributors:** arzola, fdalcin \
 **Tags:** pressbooks, plugin \
 **Requires at least:** 6.4.3 \

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,11 @@
 {
-  "name": "pressbooks-multi-institution",
+  "name": "@pressbooks/pressbooks-multi-institution",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "pressbooks-multi-institution",
-      "version": "0.1.0",
+      "name": "@pressbooks/pressbooks-multi-institution",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@pressbooks/multiselect": "^2.1.3"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
-  "name": "pressbooks-multi-institution",
-  "version": "0.1.0",
-  "description": "",
+  "name": "@pressbooks/pressbooks-multi-institution",
+  "description": "Tools for managing Pressbooks networks shared by multiple institutions",
   "main": "resources/assets/js/pressbooks-multi-institution.js",
   "scripts": {
     "build": "vite build",

--- a/pressbooks-multi-institution.php
+++ b/pressbooks-multi-institution.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * Plugin Name: Pressbooks Multi Institution
- * Plugin URI: https://pressbooks.org
+ * Plugin Name: Pressbooks Shared Network
+ * Plugin URI: https://github.com/pressbooks/pressbooks-multi-institution
  * Description: Tools for managing Pressbooks networks shared by multiple institutions
  * Version: 0.1.0
  * Author: Pressbooks (Book Oven Inc.)


### PR DESCRIPTION
Fix for #64. This PR changes the display name of this plugin from Pressbooks Multi Institution to 'Pressbooks Shared Network', to match the name of the SaaS product we sell to enterprise clients.

To test:
1. checkout this branch
2. visit the network plugins page and observe that the display name of this plugin is now 'Pressbooks Shared Network'
![Screenshot from 2024-02-28 09-57-46](https://github.com/pressbooks/pressbooks-multi-institution/assets/13485451/af4b112a-45a1-4349-956a-169728b6c833)
