### PR TITLE
fix: update network manager dashboard to reuse support resources code

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4419,12 +4419,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/pressbooks/pressbooks.git",
-                "reference": "01bf37c26cfe43a25ca2e9ac0154624d0c969da4"
+                "reference": "3014f037070b670259970a18bc90a1a2ec08d8dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pressbooks/pressbooks/zipball/01bf37c26cfe43a25ca2e9ac0154624d0c969da4",
-                "reference": "01bf37c26cfe43a25ca2e9ac0154624d0c969da4",
+                "url": "https://api.github.com/repos/pressbooks/pressbooks/zipball/3014f037070b670259970a18bc90a1a2ec08d8dd",
+                "reference": "3014f037070b670259970a18bc90a1a2ec08d8dd",
                 "shasum": ""
             },
             "require": {
@@ -4502,7 +4502,7 @@
                 "issues": "https://github.com/pressbooks/pressbooks/issues/",
                 "source": "https://github.com/pressbooks/pressbooks/"
             },
-            "time": "2024-02-27T15:49:26+00:00"
+            "time": "2024-03-06T01:40:15+00:00"
         },
         {
             "name": "psr/event-dispatcher",
@@ -7631,5 +7631,5 @@
         "php": "^8.1"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/pressbooks-multi-institution.php
+++ b/pressbooks-multi-institution.php
@@ -18,19 +18,19 @@ use PressbooksMultiInstitution\Bootstrap;
 use PressbooksMultiInstitution\Database\Migration;
 
 // TODO: Check if this is the best way to check for Pressbooks.
-if (!class_exists('Pressbooks\Book')) {
-    if (file_exists(__DIR__ . '/vendor/autoload.php')) {
-        require_once __DIR__ . '/vendor/autoload.php';
-    } else {
-        $title = __('Missing dependencies', 'PressbooksMultiInstitution');
-        $body = __(
-            'Please run <code>composer install</code> from the root of the plugin directory.',
-            'pressbooks-multi-institution'
-        );
+//if (!class_exists('Pressbooks\Book')) {
+if (file_exists(__DIR__ . '/vendor/autoload.php')) {
+    require_once __DIR__ . '/vendor/autoload.php';
+} else {
+    $title = __('Missing dependencies', 'PressbooksMultiInstitution');
+    $body = __(
+        'Please run <code>composer install</code> from the root of the plugin directory.',
+        'pressbooks-multi-institution'
+    );
 
-        wp_die("<h1>{$title}</h1><p>{$body}</p>");
-    }
+    wp_die("<h1>{$title}</h1><p>{$body}</p>");
 }
+//}
 
 register_activation_hook(__FILE__, [Migration::class, 'migrate']);
 register_deactivation_hook(__FILE__, [Migration::class, 'rollback']);

--- a/pressbooks-multi-institution.php
+++ b/pressbooks-multi-institution.php
@@ -18,19 +18,19 @@ use PressbooksMultiInstitution\Bootstrap;
 use PressbooksMultiInstitution\Database\Migration;
 
 // TODO: Check if this is the best way to check for Pressbooks.
-//if (!class_exists('Pressbooks\Book')) {
-if (file_exists(__DIR__ . '/vendor/autoload.php')) {
-    require_once __DIR__ . '/vendor/autoload.php';
-} else {
-    $title = __('Missing dependencies', 'PressbooksMultiInstitution');
-    $body = __(
-        'Please run <code>composer install</code> from the root of the plugin directory.',
-        'pressbooks-multi-institution'
-    );
+if (!class_exists('Pressbooks\Book')) {
+    if (file_exists(__DIR__ . '/vendor/autoload.php')) {
+        require_once __DIR__ . '/vendor/autoload.php';
+    } else {
+        $title = __('Missing dependencies', 'PressbooksMultiInstitution');
+        $body = __(
+            'Please run <code>composer install</code> from the root of the plugin directory.',
+            'pressbooks-multi-institution'
+        );
 
-    wp_die("<h1>{$title}</h1><p>{$body}</p>");
+        wp_die("<h1>{$title}</h1><p>{$body}</p>");
+    }
 }
-//}
 
 register_activation_hook(__FILE__, [Migration::class, 'migrate']);
 register_deactivation_hook(__FILE__, [Migration::class, 'rollback']);

--- a/resources/views/dashboard/institutional.blade.php
+++ b/resources/views/dashboard/institutional.blade.php
@@ -73,7 +73,7 @@
 							/>
 							{{ __('Network manager guide', 'pressbooks-multi-institution' )}}
 						</a>
-						<p>{{ __( 'Learn how to administrator your Pressbooks network from our comprehensive how-to guide.', 'pressbooks-multi-institution' ) }}</p>
+						<p>{{ __( 'Learn how to administer your Pressbooks network from our comprehensive how-to guide.', 'pressbooks-multi-institution' ) }}</p>
 					</li>
 					<li class="resources" id="forum">
 						<a href="https://pressbooks.community" target="_blank">

--- a/resources/views/dashboard/institutional.blade.php
+++ b/resources/views/dashboard/institutional.blade.php
@@ -71,7 +71,7 @@
 								src="{{ PB_PLUGIN_URL . "assets/dist/images/pb-network-guide.png" }}"
 								alt=""
 							/>
-							{{ __('Network manager guide', 'pressbooks-multi-institution' )}}
+							{{ __('Network manager guide', 'pressbooks-multi-institution' ) }}
 						</a>
 						<p>{{ __( 'Learn how to administer your Pressbooks network from our comprehensive how-to guide.', 'pressbooks-multi-institution' ) }}</p>
 					</li>

--- a/resources/views/dashboard/institutional.blade.php
+++ b/resources/views/dashboard/institutional.blade.php
@@ -65,7 +65,7 @@
 			<div class="pb-dashboard-content">
 				<h2>{{ __('Support resources', 'pressbooks-multi-institution') }}</h2>
 				<ul class="horizontal">
-					<li class="resources" id="getting-started">
+					<li class="resources" id="pressbooks-guide">
 						<a href="https://guide.pressbooks.com" target="_blank">
 							<img
 								src="{{ PB_PLUGIN_URL . "assets/dist/images/pb-network-guide.png" }}"
@@ -75,7 +75,7 @@
 						</a>
 						<p>{{ __( 'Learn how to administrator your Pressbooks network from our comprehensive how-to guide.', 'pressbooks-multi-institution' ) }}</p>
 					</li>
-					<li class="resources" id="pressbooks-guide">
+					<li class="resources" id="forum">
 						<a href="https://pressbooks.community" target="_blank">
 							<img
 								src="{{ PB_PLUGIN_URL . "assets/dist/images/pb-forum.png" }}"
@@ -85,7 +85,7 @@
 						</a>
 						<p>{{ __( 'Discuss issues of interest with other network managers and Pressbooks support staff.', 'pressbooks-multi-institution' ) }}</p>
 					</li>
-					<li class="resources" id="forum">
+					<li class="resources" id="webinars">
 						<a href="https://pressbooks.com/webinars" target="_blank">
 							<img
 								src="{{ PB_PLUGIN_URL . "assets/dist/images/pb-spotlight-series.png" }}"
@@ -95,7 +95,7 @@
 						</a>
 						<p>{{ __( 'Become a confident Pressbooks user by attending a free, live webinar.', 'pressbooks-multi-institution' ) }}</p>
 					</li>
-					<li class="resources" id="webinars">
+					<li class="resources" id="contact">
 						<a href="mailto:premiumsupport@pressbooks.com" target="_blank">
 							<img
 								src="{{ PB_PLUGIN_URL . "assets/dist/images/pb-contact-support.png" }}"
@@ -103,7 +103,7 @@
 							/>
 							{{ __('Contact Pressbooks Support', 'pressbooks-multi-institution') }}
 						</a>
-						<p>{{ __( 'Email Pressbooks\' Premium Support team to report bugs oor get personalized help.', 'pressbooks-multi-institution' ) }}</p>
+						<p>{{ __( 'Email Pressbooks\' Premium Support team to report bugs or get personalized help.', 'pressbooks-multi-institution' ) }}</p>
 					</li>
 				</ul>
 			</div>

--- a/resources/views/dashboard/institutional.blade.php
+++ b/resources/views/dashboard/institutional.blade.php
@@ -64,47 +64,46 @@
 		<div class="pb-dashboard-panel">
 			<div class="pb-dashboard-content">
 				<h2>{{ __('Support resources', 'pressbooks-multi-institution') }}</h2>
-				{{-- TODO: add link to new YouTube playlist. --}}
 				<ul class="horizontal">
 					<li class="resources" id="getting-started">
-						<a href="https://youtube.com/playlist?list=PLMFmJu3NJhevTbp5XAbdif8OloNhqOw5n" target="_blank">
-							<img
-								src="{{ PB_PLUGIN_URL . "assets/dist/images/pb-getting-started.png" }}"
-								alt=""
-							/>
-							{{ __('Getting started with Pressbooks', 'pressbooks-multi-institution' )}}
-						</a>
-						<p>{{ __( 'Watch a short video series on how to get started with Pressbooks.', 'pressbooks-multi-institution' ) }}</p>
-					</li>
-					<li class="resources" id="pressbooks-guide">
 						<a href="https://guide.pressbooks.com" target="_blank">
 							<img
-								src="{{ PB_PLUGIN_URL . "assets/dist/images/pb-guide.png" }}"
+								src="{{ PB_PLUGIN_URL . "assets/dist/images/pb-network-guide.png" }}"
 								alt=""
 							/>
-							{{ __('Pressbooks user guide', 'pressbooks-multi-institution' )}}
+							{{ __('Network manager guide', 'pressbooks-multi-institution' )}}
 						</a>
-						<p>{{ __( 'Find help and how-tos for your publishing project in this detailed handbook.', 'pressbooks-multi-institution' ) }}</p>
+						<p>{{ __( 'Learn how to administrator your Pressbooks network from our comprehensive how-to guide.', 'pressbooks-multi-institution' ) }}</p>
 					</li>
-					<li class="resources" id="forum">
+					<li class="resources" id="pressbooks-guide">
 						<a href="https://pressbooks.community" target="_blank">
 							<img
 								src="{{ PB_PLUGIN_URL . "assets/dist/images/pb-forum.png" }}"
 								alt=""
 							/>
-							{{ __('Pressbooks community forum', 'pressbooks-multi-institution' ) }}
+							{{ __('Pressbooks community forum', 'pressbooks-multi-institution' )}}
 						</a>
-						<p>{{ __( 'Discuss Pressbooks related questions with other users in our public forum.', 'pressbooks-multi-institution' ) }}</p>
+						<p>{{ __( 'Discuss issues of interest with other network managers and Pressbooks support staff.', 'pressbooks-multi-institution' ) }}</p>
 					</li>
-					<li class="resources" id="webinars">
+					<li class="resources" id="forum">
 						<a href="https://pressbooks.com/webinars" target="_blank">
 							<img
-								src="{{ PB_PLUGIN_URL . "assets/dist/images/pb-webinars.png" }}"
+								src="{{ PB_PLUGIN_URL . "assets/dist/images/pb-spotlight-series.png" }}"
 								alt=""
 							/>
-							{{ __('Pressbooks training webinars', 'pressbooks-multi-institution') }}
+							{{ __('Pressbooks webinars', 'pressbooks-multi-institution' ) }}
 						</a>
-						<p>{{ __( 'Register for free webinars to learn about Pressbooks features and best practices.', 'pressbooks-multi-institution' ) }}</p>
+						<p>{{ __( 'Become a confident Pressbooks user by attending a free, live webinar.', 'pressbooks-multi-institution' ) }}</p>
+					</li>
+					<li class="resources" id="webinars">
+						<a href="mailto:premiumsupport@pressbooks.com" target="_blank">
+							<img
+								src="{{ PB_PLUGIN_URL . "assets/dist/images/pb-contact-support.png" }}"
+								alt=""
+							/>
+							{{ __('Contact Pressbooks Support', 'pressbooks-multi-institution') }}
+						</a>
+						<p>{{ __( 'Email Pressbooks\' Premium Support team to report bugs oor get personalized help.', 'pressbooks-multi-institution' ) }}</p>
 					</li>
 				</ul>
 			</div>

--- a/resources/views/dashboard/institutional.blade.php
+++ b/resources/views/dashboard/institutional.blade.php
@@ -60,53 +60,5 @@
 				</div>
 			</div>
 		</div>
-	<div class="pb-dashboard-row">
-		<div class="pb-dashboard-panel">
-			<div class="pb-dashboard-content">
-				<h2>{{ __('Support resources', 'pressbooks-multi-institution') }}</h2>
-				<ul class="horizontal">
-					<li class="resources" id="pressbooks-guide">
-						<a href="https://guide.pressbooks.com" target="_blank">
-							<img
-								src="{{ PB_PLUGIN_URL . "assets/dist/images/pb-network-guide.png" }}"
-								alt=""
-							/>
-							{{ __('Network manager guide', 'pressbooks-multi-institution' ) }}
-						</a>
-						<p>{{ __( 'Learn how to administer your Pressbooks network from our comprehensive how-to guide.', 'pressbooks-multi-institution' ) }}</p>
-					</li>
-					<li class="resources" id="forum">
-						<a href="https://pressbooks.community" target="_blank">
-							<img
-								src="{{ PB_PLUGIN_URL . "assets/dist/images/pb-forum.png" }}"
-								alt=""
-							/>
-							{{ __('Pressbooks community forum', 'pressbooks-multi-institution' )}}
-						</a>
-						<p>{{ __( 'Discuss issues of interest with other network managers and Pressbooks support staff.', 'pressbooks-multi-institution' ) }}</p>
-					</li>
-					<li class="resources" id="webinars">
-						<a href="https://pressbooks.com/webinars" target="_blank">
-							<img
-								src="{{ PB_PLUGIN_URL . "assets/dist/images/pb-spotlight-series.png" }}"
-								alt=""
-							/>
-							{{ __('Pressbooks webinars', 'pressbooks-multi-institution' ) }}
-						</a>
-						<p>{{ __( 'Become a confident Pressbooks user by attending a free, live webinar.', 'pressbooks-multi-institution' ) }}</p>
-					</li>
-					<li class="resources" id="contact">
-						<a href="mailto:premiumsupport@pressbooks.com" target="_blank">
-							<img
-								src="{{ PB_PLUGIN_URL . "assets/dist/images/pb-contact-support.png" }}"
-								alt=""
-							/>
-							{{ __('Contact Pressbooks Support', 'pressbooks-multi-institution') }}
-						</a>
-						<p>{{ __( 'Email Pressbooks\' Premium Support team to report bugs or get personalized help.', 'pressbooks-multi-institution' ) }}</p>
-					</li>
-				</ul>
-			</div>
-		</div>
-	</div>
+	@include('admin.dashboard.support')
 </div>


### PR DESCRIPTION
resolves: https://github.com/pressbooks/pressbooks-multi-institution/issues/39

This PR uses the blade file from pressbooks/pressbooks to display the support resources block in institutional manager's dashboard.