### PR TITLE
fix: unassigned filter and get complete users list

### DIFF
--- a/src/Actions/PermissionsManager.php
+++ b/src/Actions/PermissionsManager.php
@@ -157,23 +157,23 @@ class PermissionsManager
 
         if ($filtered && is_super_admin() && ! get_institution_by_manager()) {
             $institutionIds = array_map('intval', $_GET['institution']);
-            $userIds = [];
             if (in_array(0, $institutionIds)) {
                 $wpUsers = get_users([
+                    'blog_id' => 0,
                     'fields' => ['ID'],
                     'exclude' => InstitutionUser::get()->pluck('user_id')->toArray(),
                 ]);
-                $userIds = array_map(fn ($user) => $user->ID, $wpUsers);
+                $userIds = array_map(fn ($user) => is_object($user) ? $user->ID : $user, $wpUsers);
             }
 
             return array_merge(
-                $userIds,
+                $userIds ?? [],
                 InstitutionUser::query()->whereIn('institution_id', $institutionIds)->pluck('user_id')->toArray()
             );
         }
 
         if (is_super_admin() && !is_restricted()) {
-            return array_map(fn ($user) => $user->ID, get_users());
+            return array_map(fn ($user) => $user->ID, get_users(['blog_id' => 0]));
         }
 
         $institutionalUsers = InstitutionUser::query()->byInstitution(get_institution_by_manager())->pluck('user_id')->toArray();

--- a/tests/Feature/Actions/PermissionsManagerTest.php
+++ b/tests/Feature/Actions/PermissionsManagerTest.php
@@ -144,7 +144,7 @@ class PermissionsManagerTest extends TestCase
         ]);
 
         $_GET['institution'] = [0];
-        $this->assertCount(4, $this->permissionsManager->filterUsersList());
+        $this->assertCount(count(get_users(['blog_id' => 0])), $this->permissionsManager->filterUsersList());
     }
 
     /**
@@ -164,7 +164,7 @@ class PermissionsManagerTest extends TestCase
 
         $users = $this->permissionsManager->filterUsersList();
 
-        $this->assertCount(count(get_users()), $users);
+        $this->assertCount(count(get_users(['blog_id' => 0])), $users);
     }
 
     /**
@@ -176,7 +176,7 @@ class PermissionsManagerTest extends TestCase
 
         $this->setSuperAdminUser();
 
-        $wpUsers = get_users();
+        $wpUsers = get_users(['blog_id' => 0]);
         $wpUserIds = array_map(fn ($user) => $user->ID, $wpUsers);
 
         $_GET['institution'] = [0];
@@ -317,7 +317,7 @@ class PermissionsManagerTest extends TestCase
     {
         $this->createInstitutionsUsers(2, 10);
 
-        $wpUsers = get_users();
+        $wpUsers = get_users(['blog_id' => 0]);
 
         $wpUsers = array_map(fn ($user) => (object) [
             'id' => $user->ID,
@@ -371,9 +371,6 @@ class PermissionsManagerTest extends TestCase
 
     public function tearDown(): void
     {
-        InstitutionUser::query()->delete();
-        Institution::query()->delete();
-
         global $wpdb;
         $wpdb->query("DELETE FROM {$wpdb->usermeta}");
         $wpdb->query("DELETE FROM {$wpdb->users}");

--- a/tests/Feature/Actions/PermissionsManagerTest.php
+++ b/tests/Feature/Actions/PermissionsManagerTest.php
@@ -106,6 +106,7 @@ class PermissionsManagerTest extends TestCase
 
         $this->assertCount(InstitutionUser::byInstitution($institutionId)->count(), $users);
     }
+
     /**
      * @test
      */
@@ -124,6 +125,26 @@ class PermissionsManagerTest extends TestCase
             InstitutionUser::query()->whereIn('institution_id', $institutions)->count(),
             $this->permissionsManager->filterUsersList()
         );
+    }
+
+    /**
+     * @test
+     */
+    public function it_filters_for_network_managers_without_institutions(): void
+    {
+        $this->setSuperAdminUser();
+
+        $this->newUser([
+            'user_login' => 'user1',
+            'user_email' => 'user1@test.pb',
+        ]);
+        $this->newUser([
+            'user_login' => 'user2',
+            'user_email' => 'user2@test.pb',
+        ]);
+
+        $_GET['institution'] = [0];
+        $this->assertCount(4, $this->permissionsManager->filterUsersList());
     }
 
     /**


### PR DESCRIPTION
Issue: https://github.com/pressbooks/pressbooks-multi-institution/issues/90

This PR gets the complete users list by adding `blog_id = 0` param in the `get_users` WP function. That way, we get the entire user list for the network.

On the other hand, when there are no institutions created in the DB, and the `unassigned` filter is applied in the users' list, the `wp_users` method is called with the `exclude => []` param. It returns a list of strings (user IDs), instead of objects as we may expect then the `exclude` parameter contains a list of IDs to exclude. This PR also fixes this.


### Testing cases
- Deactivate and activate the plugin to clean up the DB.
- Log in as a super admin user.
- Go to Users > Root Users.
- Pick one user and remove her from the Root Site users list.
- Previously: You will not be able to see her in Users > Network Users anymore, except if you add her again to the Root Site users list. With this fix, you should see ALL the users in the network independently if the user is or not in the Root Site.
- In Users > Network Users go to the Institution tab and filter by `unassigned` institution
- You should see all the users, as expected.
- Add institution, assign users to it and apply the filter again in Network Users, it should filter as expected.
- 