### PR TITLE
fix: add institutions menu to the root site level

### DIFF
--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -104,7 +104,9 @@ final class Bootstrap
     private function registerActions(): void
     {
         add_action('network_admin_menu', [$this, 'registerMenus'], 11);
-        add_action('admin_menu', [$this, 'registerMenus'], 11);
+		if ( is_main_site() ) {
+			add_action('admin_menu', [$this, 'registerMenus'], 11);
+		}
         add_action('user_register', fn (int $id) => app(AssignUserToInstitution::class)->handle($id));
         add_action('pb_new_blog', fn () => app(AssignBookToInstitution::class)->handle());
         add_action('network_admin_menu', fn () => app(PermissionsManager::class)->handleMenus(), 1000);

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -104,6 +104,7 @@ final class Bootstrap
     private function registerActions(): void
     {
         add_action('network_admin_menu', [$this, 'registerMenus'], 11);
+        add_action('admin_menu', [$this, 'registerMenus'], 11);
         add_action('user_register', fn (int $id) => app(AssignUserToInstitution::class)->handle($id));
         add_action('pb_new_blog', fn () => app(AssignBookToInstitution::class)->handle());
         add_action('network_admin_menu', fn () => app(PermissionsManager::class)->handleMenus(), 1000);

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -104,9 +104,9 @@ final class Bootstrap
     private function registerActions(): void
     {
         add_action('network_admin_menu', [$this, 'registerMenus'], 11);
-		if ( is_main_site() ) {
-			add_action('admin_menu', [$this, 'registerMenus'], 11);
-		}
+        if (is_main_site()) {
+            add_action('admin_menu', [$this, 'registerMenus'], 11);
+        }
         add_action('user_register', fn (int $id) => app(AssignUserToInstitution::class)->handle($id));
         add_action('pb_new_blog', fn () => app(AssignBookToInstitution::class)->handle());
         add_action('network_admin_menu', fn () => app(PermissionsManager::class)->handleMenus(), 1000);


### PR DESCRIPTION
Issue: https://github.com/pressbooks/pressbooks-multi-institution/issues/96

This PR adds the Institutions menu and submenu items for the root site level, thereby, when the user navigates the admin interface at the root site level, the Institution pages and menu items are created and available.

### Testing case
Follow: https://github.com/pressbooks/pressbooks-multi-institution/issues/96 steps