### PR TITLE
fix: dynamic list url for unassigned institution filter

### DIFF
--- a/resources/views/assign/index.blade.php
+++ b/resources/views/assign/index.blade.php
@@ -36,13 +36,13 @@
 		<div>
 			<ul class="subsubsub">
 				<li class="all">
-					<a href="{{$list_url}}" class="{{ ! empty($_GET['unassigned']) ? '' : 'current' }}">
+					<a href="{{ $list_url }}" class="{{ ! empty($_GET['unassigned']) ? '' : 'current' }}">
 						{{ __('All', 'pressbooks-multi-institution') }}
 						<span class="count">({{ $all_count }})</span>
 					</a> |
 				</li>
 				<li class="unassigned">
-					<a href="{{$list_url . '&unassigned=1'}}" class="{{ empty($_GET['unassigned']) ? '' : 'current' }}">
+					<a href="{{ $list_url . '&unassigned=1' }}" class="{{ empty($_GET['unassigned']) ? '' : 'current' }}">
 						{{ __('Unassigned', 'pressbooks-multi-institution') }}
 						<span class="count">({{ $unassigned_count }})</span>
 					</a>

--- a/resources/views/assign/index.blade.php
+++ b/resources/views/assign/index.blade.php
@@ -36,13 +36,13 @@
 		<div>
 			<ul class="subsubsub">
 				<li class="all">
-					<a href="?page=pb_multi_institutions_users" class="{{ ! empty($_GET['unassigned']) ? '' : 'current' }}">
+					<a href="{{$list_url}}" class="{{ ! empty($_GET['unassigned']) ? '' : 'current' }}">
 						{{ __('All', 'pressbooks-multi-institution') }}
 						<span class="count">({{ $all_count }})</span>
 					</a> |
 				</li>
 				<li class="unassigned">
-					<a href="?page=pb_multi_institutions_users&unassigned=1" class="{{ empty($_GET['unassigned']) ? '' : 'current' }}">
+					<a href="{{$list_url . '&unassigned=1'}}" class="{{ empty($_GET['unassigned']) ? '' : 'current' }}">
 						{{ __('Unassigned', 'pressbooks-multi-institution') }}
 						<span class="count">({{ $unassigned_count }})</span>
 					</a>


### PR DESCRIPTION
This PR fixes https://github.com/pressbooks/pressbooks-multi-institution/issues/104#issuecomment-2009649394

### Testing case
- Go to Insitutions > Assign Users and click on the `Unassigned` filter. It should link as expected.
- Repeat it by clicking on `All` Filter.
- Go to Insitutions > Assign Books and click on the `Unassigned` filter. It should link as expected.
- Repeat it by clicking on `All` Filter.