### PR TITLE
fix: get page context to return institutions filter

### DIFF
--- a/src/Actions/PermissionsManager.php
+++ b/src/Actions/PermissionsManager.php
@@ -193,11 +193,12 @@ class PermissionsManager
 
     public function addInstitutionsFilterTab(array $filters): array
     {
-        if (! is_super_admin() || get_institution_by_manager() > 0) {
+        $current_page = $_GET['page'] ?? false;
+
+        if (! $current_page || ! is_super_admin() || get_institution_by_manager() > 0) {
             return $filters;
         }
 
-        $current_page = $_GET['page'] ?? '';
         $whereHas = $current_page === 'pb_network_analytics_booklist' ? 'books' : 'users';
 
         return [

--- a/src/Actions/PermissionsManager.php
+++ b/src/Actions/PermissionsManager.php
@@ -197,12 +197,15 @@ class PermissionsManager
             return $filters;
         }
 
+        $current_page = $_GET['page'] ?? '';
+        $whereHas = $current_page === 'pb_network_analytics_booklist' ? 'books' : 'users';
+
         return [
             ...$filters,
             [
                 'tab' => app('Blade')->render('PressbooksMultiInstitution::partials.filters.institutions.tab'),
                 'content' => app('Blade')->render('PressbooksMultiInstitution::partials.filters.institutions.content', [
-                    'institutions' => Institution::query()->whereHas('books')->orderBy('name')->get(),
+                    'institutions' => Institution::query()->whereHas($whereHas)->orderBy('name')->get(),
                 ])
             ]
         ];

--- a/src/Actions/PermissionsManager.php
+++ b/src/Actions/PermissionsManager.php
@@ -193,13 +193,13 @@ class PermissionsManager
 
     public function addInstitutionsFilterTab(array $filters): array
     {
-        $current_page = $_GET['page'] ?? false;
+        $currentPage = $_GET['page'] ?? false;
 
-        if (! $current_page || ! is_super_admin() || get_institution_by_manager() > 0) {
+        if (! $currentPage || ! is_super_admin() || get_institution_by_manager() > 0) {
             return $filters;
         }
 
-        $whereHas = $current_page === 'pb_network_analytics_booklist' ? 'books' : 'users';
+        $whereHas = $currentPage === 'pb_network_analytics_booklist' ? 'books' : 'users';
 
         return [
             ...$filters,

--- a/src/Actions/PermissionsManager.php
+++ b/src/Actions/PermissionsManager.php
@@ -199,14 +199,14 @@ class PermissionsManager
             return $filters;
         }
 
-        $whereHas = $currentPage === 'pb_network_analytics_booklist' ? 'books' : 'users';
+        $associatedEntity = $currentPage === 'pb_network_analytics_booklist' ? 'books' : 'users';
 
         return [
             ...$filters,
             [
                 'tab' => app('Blade')->render('PressbooksMultiInstitution::partials.filters.institutions.tab'),
                 'content' => app('Blade')->render('PressbooksMultiInstitution::partials.filters.institutions.content', [
-                    'institutions' => Institution::query()->whereHas($whereHas)->orderBy('name')->get(),
+                    'institutions' => Institution::query()->whereHas($associatedEntity)->orderBy('name')->get(),
                 ])
             ]
         ];

--- a/tests/Feature/Actions/PermissionsManagerTest.php
+++ b/tests/Feature/Actions/PermissionsManagerTest.php
@@ -204,20 +204,9 @@ class PermissionsManagerTest extends TestCase
         $this->setSuperAdminUser();
         $this->createInstitutionsUsers(2, 10);
 
-        $bookId1 = $this->runWithoutFilter('pb_new_blog', fn () => $this->newBook(
-            ['path' => 'fakepath', 'title' => 'Book 1', 'no_collector' => true]
-        ));
-        $bookId2 = $this->runWithoutFilter('pb_new_blog', fn () => $this->newBook(
-            ['path' => 'anotherfakepath', 'title' => 'Book 2', 'no_collector' => true]
-        ));
-
         $institutions = Institution::query()->get();
 
-        $institution1 = $institutions[0];
-        $institution2 = $institutions[1];
-
-        $institution1->books()->create(['blog_id' => $bookId1]);
-        $institution2->books()->create(['blog_id' => $bookId2]);
+        $_GET['page'] = 'pb_network_analytics_userlist';
 
         $data = $this->permissionsManager->addInstitutionsFilterTab([])[0];
 
@@ -253,10 +242,10 @@ class PermissionsManagerTest extends TestCase
         ]);
         wp_set_current_user($regularUserId);
 
+        $_GET['page'] = 'pb_network_analytics_booklist';
+
         $this->assertEmpty($this->permissionsManager->addInstitutionsFilterTab([]));
         InstitutionBook::query()->delete();
-        wp_delete_site($bookId1);
-        wp_delete_site($bookId2);
     }
 
     /**


### PR DESCRIPTION
When any book is assigned to an institution, the super admin / NM cannot filter by that institution in the user list.
This PR fixes it by checking the current page to return the institution's list depending on the context (books/users) page.


### Testing case
- Create an institution without any book assigned to it.
- Assign one or more users to the new institution.
- Go to the Users list and make sure all the institutions with >=1 user are available for filtering.