### PR TITLE
fix: action parameters permissions

### DIFF
--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -50,11 +50,11 @@ function get_institution_books(): array
 function get_allowed_pages(): array
 {
     return [
-        'admin.php' => ['pb_network_analytics_booklist', 'pb_network_analytics_userlist', 'pb_network_analytics_admin', 'pb_cloner'],
-        'sites.php' => ['confirm', 'delete', 'pb_network_analytics_booklist', 'pb_network_analytics_userlist', 'pb_network_analytics_admin', 'pb_cloner'],
+        'admin.php' => ['pb_network_analytics_booklist', 'pb_network_analytics_userlist', 'pb_network_analytics_admin', 'pb_cloner','delete'],
+        'sites.php' => ['confirm', 'delete', 'pb_network_analytics_booklist', 'pb_network_analytics_userlist', 'pb_network_analytics_admin', 'pb_cloner','activateblog','deactivateblog'],
         'index.php' => ['', 'book_dashboard', 'pb_institutional_manager', 'pb_home_page', 'pb_catalog','pb_network_page'],
         'tools.php',
-        'users.php',
+        'users.php' => ['deleteuser','dodelete'],
         'admin-ajax.php',
         'options-general.php',
         'profile.php' => [''],

--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -51,7 +51,7 @@ function get_allowed_pages(): array
 {
     return [
         'admin.php' => ['pb_network_analytics_booklist', 'pb_network_analytics_userlist', 'pb_network_analytics_admin', 'pb_cloner','delete'],
-        'sites.php' => ['confirm', 'delete', 'pb_network_analytics_booklist', 'pb_network_analytics_userlist', 'pb_network_analytics_admin', 'pb_cloner','activateblog','deactivateblog'],
+        'sites.php' => ['confirm', 'delete', 'pb_network_analytics_booklist', 'pb_network_analytics_userlist', 'pb_network_analytics_admin', 'pb_cloner','activateblog','deactivateblog', 'deleteblog'],
         'index.php' => ['', 'book_dashboard', 'pb_institutional_manager', 'pb_home_page', 'pb_catalog','pb_network_page'],
         'tools.php',
         'users.php' => ['deleteuser','dodelete'],

--- a/src/Views/UserList.php
+++ b/src/Views/UserList.php
@@ -64,14 +64,14 @@ class UserList extends BaseInstitutionList
         $idSubQuery = $this->db
             ->table('institutions')
             ->select('institutions.id')
-            ->join('institutions_blogs', 'institutions.id', '=', 'institutions_blogs.institution_id')
+            ->leftjoin('institutions_blogs', 'institutions.id', '=', 'institutions_blogs.institution_id')
             ->join('institutions_users', 'institutions.id', '=', 'institutions_users.institution_id')
             ->whereRaw("{$prefix}institutions_users.user_id = us.id")->limit(1);
 
         $nameSubQuery = $this->db
             ->table('institutions')
             ->select('institutions.name')
-            ->join('institutions_blogs', 'institutions.id', '=', 'institutions_blogs.institution_id')
+            ->leftjoin('institutions_blogs', 'institutions.id', '=', 'institutions_blogs.institution_id')
             ->join('institutions_users', 'institutions.id', '=', 'institutions_users.institution_id')
             ->whereRaw("{$prefix}institutions_users.user_id = us.id")->limit(1);
 

--- a/tests/Feature/Views/UserListTest.php
+++ b/tests/Feature/Views/UserListTest.php
@@ -127,7 +127,7 @@ class UserListTest extends TestCase
     {
         Container::get(UserList::class)->init();
 
-        $expected = "(select `wptests_institutions`.`id` from `wptests_institutions` inner join `wptests_institutions_blogs` on `wptests_institutions`.`id` = `wptests_institutions_blogs`.`institution_id` inner join `wptests_institutions_users` on `wptests_institutions`.`id` = `wptests_institutions_users`.`institution_id` where wptests_institutions_users.user_id = us.id limit 1) as institution_id, (select `wptests_institutions`.`name` from `wptests_institutions` inner join `wptests_institutions_blogs` on `wptests_institutions`.`id` = `wptests_institutions_blogs`.`institution_id` inner join `wptests_institutions_users` on `wptests_institutions`.`id` = `wptests_institutions_users`.`institution_id` where wptests_institutions_users.user_id = us.id limit 1) as institution";
+        $expected = "(select `wptests_institutions`.`id` from `wptests_institutions` left join `wptests_institutions_blogs` on `wptests_institutions`.`id` = `wptests_institutions_blogs`.`institution_id` inner join `wptests_institutions_users` on `wptests_institutions`.`id` = `wptests_institutions_users`.`institution_id` where wptests_institutions_users.user_id = us.id limit 1) as institution_id, (select `wptests_institutions`.`name` from `wptests_institutions` left join `wptests_institutions_blogs` on `wptests_institutions`.`id` = `wptests_institutions_blogs`.`institution_id` inner join `wptests_institutions_users` on `wptests_institutions`.`id` = `wptests_institutions_users`.`institution_id` where wptests_institutions_users.user_id = us.id limit 1) as institution";
         $this->assertEquals($expected, apply_filters('pb_network_analytics_user_list_select_clause', ''));
     }
 


### PR DESCRIPTION
This PR address permissions issues described in #131 

I changed the join condition for a leftJoin to being able to perform the query even when there are no books assigned to the institution