### PR TITLE
chore: update CodeCov actions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -27,6 +27,9 @@ jobs:
 
     name: Tests - PHP ${{ matrix.php }} - WP ${{ matrix.wordpress }}
 
+    outputs:
+      coverage: ${{ matrix.experimental == false }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -78,12 +78,13 @@ jobs:
         if: matrix.experimental == false
 
       - name: Save code coverage to artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: matrix.experimental == false
         with:
           name: code-coverage
           path: "coverage.xml"
           retention-days: 5
+          overwrite: true
 
       - name: Prepare Build
         if: startsWith(github.ref, 'refs/tags/') && matrix.experimental == false
@@ -134,10 +135,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Fetch code coverage artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: code-coverage
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          slug: pressbooks/pressbooks-multi-institution

--- a/codecov.yml
+++ b/codecov.yml
@@ -12,7 +12,7 @@ coverage:
     patch: true
     changes: false
 
-  notify:
+ # notify:
     # slack:
     #   default:
     #     url: ""

--- a/codecov.yml
+++ b/codecov.yml
@@ -12,11 +12,6 @@ coverage:
     patch: true
     changes: false
 
- # notify:
-    # slack:
-    #   default:
-    #     url: ""
-    #     threshold: 1%
 parsers:
   gcov:
     branch_detection:


### PR DESCRIPTION
This plugin was not configured correctly to add or update Codecov reports showing the level of code coverage this plugin had achieved. This PR addresses https://github.com/pressbooks/pressbooks-multi-institution/issues/143 by updating Codecov and related actions to the 4.x branch and adding the CODECOV_TOKEN secret that is now required by the underlying CLI. See https://github.com/pressbooks/pressbooks/issues/3665 for additional reference details. You can confirm that codecov uploads work by visiting: https://app.codecov.io/gh/pressbooks/pressbooks-multi-institution/pull/142/tree

![Screenshot from 2024-04-02 16-57-28](https://github.com/pressbooks/pressbooks-multi-institution/assets/13485451/ec0e95dc-0a18-4f09-8fe4-c46e195f0e08)