### PR TITLE
feat: add institution info for network/users.php page

### DIFF
--- a/resources/views/table/wp-users/books-column.blade.php
+++ b/resources/views/table/wp-users/books-column.blade.php
@@ -1,0 +1,16 @@
+@foreach ($books as $book)
+	<span class="site-1">
+		<a href="{{ $book->siteurl }}/wp-admin">
+			{{ $book->domain . $book->path }}
+		</a>
+		<small class="row-actions">
+			<span class="edit">
+				<a href="{{ $book->siteurl }}/wp-admin">{{ __('Dashboard', 'pressbooks-multi-institution') }}</a> |
+			</span>
+			<span class="view">
+				<a href="{{ $book->siteurl }}">{{ __('View', 'pressbooks-multi-institution') }}</a>
+			</span>
+		</small>
+	</span>
+	<br />
+@endforeach

--- a/src/Actions/AssignUserToInstitution.php
+++ b/src/Actions/AssignUserToInstitution.php
@@ -4,6 +4,9 @@ namespace PressbooksMultiInstitution\Actions;
 
 use Illuminate\Support\Str;
 use PressbooksMultiInstitution\Models\Institution;
+use WP_User;
+
+use function PressbooksMultiInstitution\Support\get_institution_by_manager;
 
 class AssignUserToInstitution
 {
@@ -15,6 +18,14 @@ class AssignUserToInstitution
             return false;
         }
 
+        $institution = get_institution_by_manager();
+
+        return $institution === 0 ?
+            $this->assignByUserDomain($user) : $this->assignUserByInstitution($user, $institution);
+    }
+
+    private function assignByUserDomain(WP_User $user): bool
+    {
         $email = Str::of($user->user_email);
 
         $domain = (string) $email->after('@')->trim();
@@ -27,7 +38,18 @@ class AssignUserToInstitution
         }
 
         $institution->users()->create([
-            'user_id' => $userId,
+            'user_id' => $user->ID,
+        ]);
+
+        return true;
+    }
+
+    private function assignUserByInstitution(WP_User $user, int $institution): bool
+    {
+        $institution = Institution::find($institution);
+
+        $institution->users()->create([
+            'user_id' => $user->ID,
         ]);
 
         return true;

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -41,6 +41,7 @@ final class Bootstrap
 
         Container::getInstance()->singleton(BookList::class, fn () => new BookList(app('db')));
         Container::getInstance()->singleton(UserList::class, fn () => new UserList(app('db')));
+        Container::getInstance()->singleton(WpUserList::class, fn () => new WpUserList);
     }
 
     private function registerActions(): void
@@ -62,7 +63,6 @@ final class Bootstrap
         );
         add_action('init', [InstitutionalManagerDashboard::class, 'init']);
         add_action('init', fn () => app(InstitutionStatsService::class)->setupHooks());
-        add_action('init', fn () => app(WpUserList::class)->setupHooks());
     }
 
     private function registerBlade(): void

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -11,7 +11,7 @@ use PressbooksMultiInstitution\Services\InstitutionStatsService;
 use PressbooksMultiInstitution\Services\MenuManager;
 use PressbooksMultiInstitution\Services\PermissionsManager;
 use PressbooksMultiInstitution\Views\BookList;
-use PressbooksMultiInstitution\Views\OsUserList;
+use PressbooksMultiInstitution\Views\WpUserList;
 use PressbooksMultiInstitution\Views\UserList;
 
 /**
@@ -62,7 +62,7 @@ final class Bootstrap
         );
         add_action('init', [InstitutionalManagerDashboard::class, 'init']);
         add_action('init', fn () => app(InstitutionStatsService::class)->setupHooks());
-        add_action('init', fn () => app(OsUserList::class)->setupHooks());
+        add_action('init', fn () => app(WpUserList::class)->setupHooks());
     }
 
     private function registerBlade(): void

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -11,6 +11,7 @@ use PressbooksMultiInstitution\Services\InstitutionStatsService;
 use PressbooksMultiInstitution\Services\MenuManager;
 use PressbooksMultiInstitution\Services\PermissionsManager;
 use PressbooksMultiInstitution\Views\BookList;
+use PressbooksMultiInstitution\Views\OsUserList;
 use PressbooksMultiInstitution\Views\UserList;
 
 /**
@@ -61,6 +62,7 @@ final class Bootstrap
         );
         add_action('init', [InstitutionalManagerDashboard::class, 'init']);
         add_action('init', fn () => app(InstitutionStatsService::class)->setupHooks());
+        add_action('init', fn () => app(OsUserList::class)->setupHooks());
     }
 
     private function registerBlade(): void

--- a/src/Services/MenuManager.php
+++ b/src/Services/MenuManager.php
@@ -86,21 +86,35 @@ class MenuManager
         if (!is_main_site() || !is_super_admin()) {
             unset($submenu['index.php'][0]);
         }
+
         if (get_institution_by_manager() !== 0) {
-            remove_menu_page($this->getContextSlug('customize.php', true));
-            remove_menu_page($this->getContextSlug('edit.php?post_type=page', true));
-            // Remove the default dashboard page and point to the institutional dashboard
-            foreach ($menu as &$item) {
-                if ($item[2] == network_admin_url('index.php')) {
-                    $item[2] = network_site_url('wp-admin/index.php?page=pb_institutional_manager');
-                    break;
-                }
-            }
-            remove_menu_page($this->getContextSlug('admin.php?page=pb_network_integrations', false));
-            remove_menu_page('settings.php');
-            remove_menu_page('pb_network_integrations');
-            remove_menu_page($this->slug);
+            $this->removeMenuItems($menu);
+
             add_action('admin_bar_menu', [$this, 'modifyAdminBarMenus'], 1000);
+
+            if (count($submenu['users.php']) > 1) {
+                // remove submenu items for users menu
+                $submenu['users.php'] = array_slice($submenu['users.php'], 0, 1);
+            }
+        }
+    }
+
+    private function removeMenuItems(array &$menu): void
+    {
+        remove_menu_page($this->getContextSlug('customize.php', true));
+        remove_menu_page($this->getContextSlug('edit.php?post_type=page', true));
+        remove_menu_page($this->getContextSlug('admin.php?page=pb_network_integrations', false));
+        remove_menu_page('settings.php');
+        remove_menu_page('pb_network_integrations');
+        remove_menu_page($this->slug);
+        remove_menu_page('h5p');
+
+        // Remove the default dashboard page and point to the institutional dashboard
+        foreach ($menu as &$item) {
+            if ($item[2] == network_admin_url('index.php')) {
+                $item[2] = network_site_url('wp-admin/index.php?page=pb_institutional_manager');
+                break;
+            }
         }
     }
 

--- a/src/Services/PermissionsManager.php
+++ b/src/Services/PermissionsManager.php
@@ -65,7 +65,7 @@ class PermissionsManager
          */
 
         add_filter('can_edit_network', function ($canEdit) use ($allowedBooks) {
-            if (is_network_admin() && !in_array($_REQUEST['id'], $allowedBooks)) {
+            if (is_network_admin() && isset($_REQUEST['id']) && !in_array($_REQUEST['id'], $allowedBooks)) {
                 $canEdit = false;
             }
             return $canEdit;
@@ -188,8 +188,10 @@ class PermissionsManager
         $institutionalUsers = apply_filters('pb_institutional_users', []);
 
         if ($currentPageParam === 'pb_network_analytics_userlist' || $pagenow === 'users.php' || $pagenow === 'user-edit.php') {
-            if (isset($_REQUEST['user_id']) && in_array($_REQUEST['user_id'], $institutionalUsers)) {
-                $isAccessAllowed = true;
+            $isAccessAllowed = true;
+
+            if (isset($_REQUEST['user_id']) && ! in_array($_REQUEST['user_id'], $institutionalUsers)) {
+                $isAccessAllowed = false;
             }
 
             if (isset($_REQUEST['id']) && !in_array($_REQUEST['id'], $institutionalUsers)) {

--- a/src/Services/PermissionsManager.php
+++ b/src/Services/PermissionsManager.php
@@ -9,8 +9,10 @@ use PressbooksMultiInstitution\Models\InstitutionUser;
 use PressbooksMultiInstitution\Views\BookList;
 use PressbooksMultiInstitution\Views\UserList;
 
+use PressbooksMultiInstitution\Views\WpUserList;
+
 use function Pressbooks\Admin\NetworkManagers\_restricted_users;
-use function PressbooksMultiInstitution\Support\get_allowed_book_pages;
+use function PressbooksMultiInstitution\Support\get_restricted_book_pages;
 use function PressbooksMultiInstitution\Support\get_allowed_pages;
 use function PressbooksMultiInstitution\Support\get_institution_books;
 use function PressbooksMultiInstitution\Support\get_institution_by_manager;
@@ -39,6 +41,7 @@ class PermissionsManager
         Container::get(TableViews::class)->init();
         Container::get(BookList::class)->init();
         Container::get(UserList::class)->init();
+        Container::get(WpUserList::class)->init();
 
         do_action('pb_institutional_filters_created', $institution, $institutionalManagers, $institutionalUsers);
     }
@@ -157,7 +160,7 @@ class PermissionsManager
         global $pagenow;
 
         $allowedPages = get_allowed_pages();
-        $bookPages = get_allowed_book_pages();
+        $restrictedBookPages = get_restricted_book_pages();
 
         $isAccessAllowed = false;
 
@@ -181,7 +184,10 @@ class PermissionsManager
         // Check if the current page is a book page and if the user has access to it
         $userBooks = array_slice(array_keys(get_blogs_of_user(get_current_user_id())), 1); // remove the main site
 
-        if ((in_array($currentBlogId, $userBooks) || in_array($currentBlogId, $allowedBooks)) && !in_array($pagenow, $bookPages)) {
+        if (
+            (in_array($currentBlogId, $userBooks) || in_array($currentBlogId, $allowedBooks)) &&
+            !in_array($pagenow, $restrictedBookPages)
+        ) {
             $isAccessAllowed = true;
         }
 
@@ -190,11 +196,9 @@ class PermissionsManager
         if ($currentPageParam === 'pb_network_analytics_userlist' || $pagenow === 'users.php' || $pagenow === 'user-edit.php') {
             $isAccessAllowed = true;
 
-            if (isset($_REQUEST['user_id']) && ! in_array($_REQUEST['user_id'], $institutionalUsers)) {
-                $isAccessAllowed = false;
-            }
+            $userId = $_REQUEST['id'] ?? $_REQUEST['user_id'] ?? null;
 
-            if (isset($_REQUEST['id']) && !in_array($_REQUEST['id'], $institutionalUsers)) {
+            if ($userId && ! in_array($userId, $institutionalUsers)) {
                 $isAccessAllowed = false;
             }
         }

--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -74,7 +74,7 @@ function get_allowed_pages(): array
     ];
 }
 
-function get_allowed_book_pages(): array
+function get_restricted_book_pages(): array
 {
     return [
         'site-info.php',

--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -67,6 +67,7 @@ function get_allowed_pages(): array
         'plugins.php',
         'media-new.php',
         'users.php',
+        'user-new.php',
         'export-personal-data.php',
         'erase-personal-data.php',
         'options-privacy.php'

--- a/src/Views/OsUserList.php
+++ b/src/Views/OsUserList.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace PressbooksMultiInstitution\Views;
+
+use PressbooksMultiInstitution\Models\InstitutionUser;
+
+class OsUserList
+{
+    public function setupHooks(): void
+    {
+        add_filter('wpmu_users_columns', [$this, 'addColumn']);
+        add_filter('manage_users_custom_column', [$this, 'displayInstitutionValue'], 10, 3);
+
+        add_filter('manage_users-network_sortable_columns', [$this, 'makeColumnSortable']);
+
+        add_filter('users_list_table_query_args', [$this, 'addQueryArgsSorting']);
+        add_action('pre_user_query', [$this, 'modifyUserQuery']);
+    }
+
+    public function displayInstitutionValue(string $value, string $columnName, int $userId): string
+    {
+        if ($columnName !== 'institution') {
+            return $value;
+        }
+
+        $institution = InstitutionUser::query()
+            ->where('user_id', $userId)
+            ->first()
+            ?->institution
+            ->name;
+        return $institution ?? __('Unassigned', 'pressbooks-multi-institution');
+    }
+
+    public function addColumn(array $columns): array
+    {
+        return array_slice($columns, 0, 4, true) +
+            ['institution' => __('Institution', 'pressbooks-multi-institution')] +
+            array_slice($columns, 4, null, true);
+    }
+
+    public function makeColumnSortable(array $columns): array
+    {
+        $columns['institution'] = 'institution';
+        return $columns;
+    }
+
+    public function addQueryArgsSorting(array $args): array
+    {
+        return $args;
+    }
+
+    public function modifyUserQuery(\WP_User_Query $query): void
+    {
+        global $pagenow;
+        if (!is_admin() || $pagenow !== 'users.php' || empty($_GET['orderby']) || $_GET['orderby'] !== 'institution') {
+            return;
+        }
+
+        global $wpdb;
+        $query->query_from .= " LEFT JOIN {$wpdb->base_prefix}institutions_users AS iu ON {$wpdb->users}.ID = iu.user_id";
+        $query->query_from .= " LEFT JOIN {$wpdb->base_prefix}institutions AS i ON iu.institution_id = i.id";
+
+        $order = (isset($_GET['order']) && $_GET['order'] === 'asc') ? 'ASC' : 'DESC';
+
+        $query->query_orderby = "ORDER BY i.name " . $order;
+    }
+}

--- a/src/Views/WpUserList.php
+++ b/src/Views/WpUserList.php
@@ -9,14 +9,14 @@ use WP_User_Query;
 
 use function PressbooksMultiInstitution\Support\get_institution_by_manager;
 
-class OsUserList
+class WpUserList
 {
     public function setupHooks(): void
     {
-        add_filter('wpmu_users_columns', [$this, 'addColumn']);
+        add_filter('wpmu_users_columns', [$this, 'addInstitutionColumn']);
         add_filter('manage_users_custom_column', [$this, 'displayInstitutionValue'], 10, 3);
 
-        add_filter('manage_users-network_sortable_columns', [$this, 'makeColumnSortable']);
+        add_filter('manage_users-network_sortable_columns', [$this, 'makeInstitutionColumnSortable']);
 
         add_action('pre_user_query', [$this, 'modifyUserQuery']);
 
@@ -29,22 +29,21 @@ class OsUserList
             return $value;
         }
 
-        $institution = InstitutionUser::query()
+        return InstitutionUser::query()
             ->where('user_id', $userId)
             ->first()
             ?->institution
-            ->name;
-        return $institution ?? __('Unassigned', 'pressbooks-multi-institution');
+            ->name ?? __('Unassigned', 'pressbooks-multi-institution');
     }
 
-    public function addColumn(array $columns): array
+    public function addInstitutionColumn(array $columns): array
     {
         return array_slice($columns, 0, 4, true) +
             ['institution' => __('Institution', 'pressbooks-multi-institution')] +
             array_slice($columns, 4, null, true);
     }
 
-    public function makeColumnSortable(array $columns): array
+    public function makeInstitutionColumnSortable(array $columns): array
     {
         $columns['institution'] = 'institution';
         return $columns;
@@ -81,7 +80,8 @@ class OsUserList
         unset($views['super']);
 
         $totalUsers = Institution::find($institution)->users()->count();
-        $views['all'] = "<a href='#' class='current' aria-current='page'>All <span class='count'>({$totalUsers})</span></a>";
+        $views['all'] = "<a href='#' class='current' aria-current='page'> " .
+            __('All', 'pressbooks-multi-institution') . " <span class='count'>({$totalUsers})</span></a>";
 
         return $views;
     }

--- a/tests/Feature/Views/WpUserListTest.php
+++ b/tests/Feature/Views/WpUserListTest.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace Tests\Feature\Views;
+
+use Pressbooks\Container;
+use PressbooksMultiInstitution\Models\Institution;
+use PressbooksMultiInstitution\Views\WpUserList;
+use Tests\TestCase;
+use Tests\Traits\CreatesModels;
+
+/**
+ * @group wp-user-list
+ */
+class WpUserListTest extends TestCase
+{
+    use CreatesModels;
+
+    /**
+     * @test
+     */
+    public function it_registers_hook_actions(): void
+    {
+        $this->assertFalse(has_filter('wpmu_users_columns'));
+        $this->assertFalse(has_filter('manage_users_custom_column'));
+        $this->assertFalse(has_filter('manage_users-network_sortable_columns'));
+        $this->assertFalse(has_action('pre_user_query'));
+        $this->assertFalse(has_filter('views_users-network'));
+
+        Container::get(WpUserList::class)->setupHooks();
+
+        $this->assertTrue(has_filter('wpmu_users_columns'));
+        $this->assertTrue(has_filter('manage_users_custom_column'));
+        $this->assertTrue(has_filter('manage_users-network_sortable_columns'));
+        $this->assertTrue(has_action('pre_user_query'));
+        $this->assertTrue(has_filter('views_users-network'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_displays_institution_value(): void
+    {
+        $this->createInstitutionsUsers(1, 1);
+
+        $institution = Institution::query()->first();
+        $userId =  $institution->users()->first()->user_id;
+
+        $this->assertEquals(
+            $institution->name,
+            Container::get(WpUserList::class)->displayInstitutionValue('', 'institution', $userId)
+        );
+
+        $this->assertEquals(
+            'Unassigned',
+            Container::get(WpUserList::class)->displayInstitutionValue('', 'institution', 99)
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_adds_institution_column(): void
+    {
+        $columns = ['name' => 'Name', 'email' => 'Email', 'registered' => 'Registered'];
+        $expected = ['name' => 'Name', 'email' => 'Email', 'institution' => 'Institution', 'registered' => 'Registered'];
+
+        $this->assertEquals(
+            $expected,
+            Container::get(WpUserList::class)->addInstitutionColumn($columns)
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_makes_institution_column_sortable(): void
+    {
+        $columns = ['name' => 'name', 'email' => 'email', 'registered' => 'registered'];
+        $expected = ['name' => 'name', 'email' => 'email', 'registered' => 'registered', 'institution' => 'institution'];
+
+        $this->assertEquals(
+            $expected,
+            Container::get(WpUserList::class)->makeInstitutionColumnSortable($columns)
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_modifies_user_query(): void
+    {
+        $query = new \WP_User_Query(['blog_id' => 1]);
+
+        global $pagenow;
+        $pagenow = 'users.php';
+        $userId = $this->newSuperAdmin();
+        wp_set_current_user($userId);
+        $_GET['order'] = 'desc';
+
+        Container::get(WpUserList::class)->modifyUserQuery($query);
+
+        $this->assertStringContainsString('LEFT JOIN', $query->query_from);
+        $this->assertStringContainsString('institutions_users', $query->query_from);
+        $this->assertStringContainsString('institutions', $query->query_from);
+        $this->assertStringContainsString('ORDER BY i.name DESC', $query->query_orderby);
+    }
+
+    /**
+     * @test
+     */
+    public function it_add_where_conditions_to_query_for_ims(): void
+    {
+        $query = new \WP_User_Query(['blog_id' => 1]);
+
+        $this->createInstitutionsUsers(1, 3);
+
+        $institution = Institution::query()->first();
+        $userId = $this->newInstitutionalManager($institution);
+
+        grant_super_admin($userId);
+        wp_set_current_user($userId);
+
+        global $pagenow;
+        $pagenow = 'users.php';
+
+        Container::get(WpUserList::class)->modifyUserQuery($query);
+
+        $this->assertStringContainsString('LEFT JOIN', $query->query_from);
+        $this->assertStringContainsString('institutions_users', $query->query_from);
+        $this->assertStringContainsString('institutions', $query->query_from);
+        $this->assertStringContainsString('AND iu.institution_id = ' . $institution->id, $query->query_where);
+    }
+
+    /**
+     * @test
+     */
+    public function it_removes_super_admin_filter(): void
+    {
+        $this->createInstitutionsUsers(1, 3);
+
+        $institution = Institution::query()->first();
+        $userId = $this->newInstitutionalManager($institution);
+        wp_set_current_user($userId);
+
+        $views = ['all' => 'All', 'super' => 'Super'];
+        $totalUsers = $institution->users()->count();
+
+        $this->assertEquals(
+            ['all' => "<a href='#' class='current' aria-current='page'> All <span class='count'>({$totalUsers})</span></a>"],
+            Container::get(WpUserList::class)->removeSuperAdminFilter($views)
+        );
+    }
+}


### PR DESCRIPTION
Issue: https://github.com/pressbooks/pressbooks-multi-institution/issues/42

This PR modifies the WP network user list in order to add an "Institution" sortable column with the institution name. If the user displayed in the list does not belong to any institution, it displays `Unnasigned` text.

### Testing case
- As a super admin / network manager, go to Users > Network Users.
- Make sure the `Institution` column is displayed after the `Email` one with the correct value.
- Sort by `Institution` column and make sure the ordering is correct.
- Log in as an Institutional Manager and make sure only the users belonging to the current institution are displayed.
- Edit / delete users and make sure those actions are performed as expected.
- Try to edit or delete a non-allowed user by going to `<NETWORK_URL>/network/user-edit.php?user_id=<USER_ID_FROM_OTHER_INSTITUTION>`. You should not be allowed to do that.
- Make sure the `Super Admin` filter at the top of the table is not available.
- The totals at the top of the table must match with the total number of users.