### PR TITLE
fix: update update-pot.yml parameter

### DIFF
--- a/.github/workflows/update-pot.yml
+++ b/.github/workflows/update-pot.yml
@@ -17,3 +17,4 @@ jobs:
       slug: "pressbooks-multi-institution"
       package_name: "Pressbooks Shared Network"
       headers: '{"Report-Msgid-Bugs-To": "https://github.com/pressbooks/pressbooks-multi-institution/issues"}'
+      pull_request_number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Pull request number required for the latest version of updatepot