### PR TITLE
feat: support platform assignment

### DIFF
--- a/languages/pressbooks-multi-institution.pot
+++ b/languages/pressbooks-multi-institution.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2024-10-09T14:54:43+00:00\n"
+"POT-Creation-Date: 2024-11-26T19:11:49+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.11.0\n"
 "X-Domain: pressbooks-multi-institution\n"
@@ -39,7 +39,18 @@ msgstr ""
 msgid "https://pressbooks.org"
 msgstr ""
 
-#: src/Bootstrap.php:80
+#: src/Bootstrap.php:97
+#: src/Traits/OverridesBulkActions.php:14
+#: src/Views/AssignUsersTable.php:74
+#: src/Views/BaseInstitutionList.php:108
+#: src/Views/InstitutionsTotals.php:33
+#: resources/views/assign/index.blade.php:58
+#: resources/views/partials/filters/institutions/content.blade.php:14
+#: resources/views/table/institution.blade.php:1
+msgid "Unassigned"
+msgstr ""
+
+#: src/Bootstrap.php:136
 msgid "Are you sure you want to delete the selected institutions?"
 msgstr ""
 
@@ -98,7 +109,7 @@ msgid "The book limit field should be numeric."
 msgstr ""
 
 #: src/Services/InstitutionStatsService.php:39
-#: src/Services/MenuManager.php:165
+#: src/Services/MenuManager.php:167
 msgid "%s Stats"
 msgstr ""
 
@@ -122,22 +133,12 @@ msgstr ""
 msgid "Edit Institution"
 msgstr ""
 
-#: src/Services/MenuManager.php:117
+#: src/Services/MenuManager.php:119
 msgid "Administer Institution"
 msgstr ""
 
 #: src/Services/PermissionsManager.php:95
 msgid "Sorry, you are not allowed to access this page."
-msgstr ""
-
-#: src/Traits/OverridesBulkActions.php:14
-#: src/Views/AssignUsersTable.php:74
-#: src/Views/BaseInstitutionList.php:108
-#: src/Views/InstitutionsTotals.php:33
-#: resources/views/assign/index.blade.php:58
-#: resources/views/partials/filters/institutions/content.blade.php:14
-#: resources/views/table/institution.blade.php:1
-msgid "Unassigned"
 msgstr ""
 
 #: src/Views/AssignBooksTable.php:33

--- a/languages/pressbooks-multi-institution.pot
+++ b/languages/pressbooks-multi-institution.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2024-11-26T19:11:49+00:00\n"
+"POT-Creation-Date: 2024-11-27T19:25:24+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.11.0\n"
 "X-Domain: pressbooks-multi-institution\n"
@@ -50,7 +50,7 @@ msgstr ""
 msgid "Unassigned"
 msgstr ""
 
-#: src/Bootstrap.php:136
+#: src/Bootstrap.php:138
 msgid "Are you sure you want to delete the selected institutions?"
 msgstr ""
 

--- a/languages/pressbooks-multi-institution.pot
+++ b/languages/pressbooks-multi-institution.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2024-11-27T19:25:24+00:00\n"
+"POT-Creation-Date: 2024-11-28T18:16:38+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.11.0\n"
 "X-Domain: pressbooks-multi-institution\n"
@@ -84,27 +84,27 @@ msgid_plural "Users updated."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Controllers/InstitutionsController.php:101
+#: src/Controllers/InstitutionsController.php:103
 msgid "Action completed."
 msgstr ""
 
-#: src/Controllers/InstitutionsController.php:126
+#: src/Controllers/InstitutionsController.php:128
 msgid "The form is invalid."
 msgstr ""
 
-#: src/Controllers/InstitutionsController.php:172
+#: src/Controllers/InstitutionsController.php:174
 msgid "Institution has been added."
 msgstr ""
 
-#: src/Controllers/InstitutionsController.php:173
+#: src/Controllers/InstitutionsController.php:175
 msgid "Institution has been updated."
 msgstr ""
 
-#: src/Controllers/InstitutionsController.php:200
+#: src/Controllers/InstitutionsController.php:202
 msgid "The name field is required."
 msgstr ""
 
-#: src/Controllers/InstitutionsController.php:210
+#: src/Controllers/InstitutionsController.php:212
 msgid "The book limit field should be numeric."
 msgstr ""
 

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -101,7 +101,7 @@ final class Bootstrap
 
         add_filter(
             hook_name: 'pressbooks_append_institution_to_query',
-            callback: function (EloquentBuilder $query, string $columnToCompare, string $search = '', string $order = '', string $direction = '') {
+            callback: function (EloquentBuilder $query, string $columnToCompare, string $search = '', string $order = '', string $direction = ''): EloquentBuilder {
                 $query
                     ->addSelect([
                         'institution' => Institution::query()

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -80,7 +80,7 @@ final class Bootstrap
     {
         add_filter(
             hook_name: 'pressbooks_get_institution_by_id',
-            callback: function (bool $default, string|int $id) {
+            callback: function (mixed $default, string|int $id) {
                 $institution = Institution::query()->find($id);
 
                 return $institution?->id ?? $default;
@@ -101,7 +101,7 @@ final class Bootstrap
 
         add_filter(
             hook_name: 'pressbooks_append_institution_to_query',
-            callback: function (EloquentBuilder $query, string $columnToCompare, string $search, string $order, string $direction) {
+            callback: function (EloquentBuilder $query, string $columnToCompare, string $search = '', string $order = '', string $direction = '') {
                 $query
                     ->addSelect([
                         'institution' => Institution::query()
@@ -122,6 +122,8 @@ final class Bootstrap
                             ->orderByRaw($direction === 'asc' ? 'institution IS NOT NULL' : 'institution IS NULL')
                             ->orderBy('institution', $direction);
                     });
+
+                return $query;
             },
             accepted_args: 5
         );

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -2,11 +2,14 @@
 
 namespace PressbooksMultiInstitution;
 
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Database\Query\Builder;
 use Kucrut\Vite;
 use Pressbooks\Container;
 use PressbooksMultiInstitution\Actions\AssignBookToInstitution;
 use PressbooksMultiInstitution\Actions\AssignUserToInstitution;
 use PressbooksMultiInstitution\Actions\InstitutionalManagerDashboard;
+use PressbooksMultiInstitution\Models\Institution;
 use PressbooksMultiInstitution\Services\InstitutionStatsService;
 use PressbooksMultiInstitution\Services\MenuManager;
 use PressbooksMultiInstitution\Services\PermissionsManager;
@@ -40,6 +43,8 @@ final class Bootstrap
 
         Container::getInstance()->singleton(BookList::class, fn () => new BookList(app('db')));
         Container::getInstance()->singleton(UserList::class, fn () => new UserList(app('db')));
+
+        $this->registerInstitutionHooks();
     }
 
     private function registerActions(): void
@@ -68,6 +73,57 @@ final class Bootstrap
         app('Blade')->addNamespace(
             'PressbooksMultiInstitution',
             dirname(__DIR__) . '/resources/views'
+        );
+    }
+
+    private function registerInstitutionHooks(): void
+    {
+        add_filter(
+            hook_name: 'pressbooks_get_institution_by_id',
+            callback: function (bool $default, string|int $id) {
+                $institution = Institution::query()->find($id);
+
+                return $institution?->id ?? $default;
+            },
+            accepted_args: 2
+        );
+
+        add_filter(
+            hook_name: 'pressbooks_get_institution_dropdown',
+            callback: function (array $default) {
+                return Institution::query()
+                    ->orderBy('name')
+                    ->pluck('name', 'id')
+                    ->prepend(__('Unassigned', 'pressbooks-multi-institution'), 0)
+                    ->toArray();
+            },
+        );
+
+        add_filter(
+            hook_name: 'pressbooks_append_institution_to_query',
+            callback: function (EloquentBuilder $query, string $columnToCompare, string $search, string $order, string $direction) {
+                $query
+                    ->addSelect([
+                        'institution' => Institution::query()
+                            ->select('name')
+                            ->whereColumn('id', '=', $columnToCompare)
+                    ])
+                    ->when($search, function (EloquentBuilder $query, string $value) use ($columnToCompare) {
+                        $query->orWhereExists(function (Builder $query) use ($value, $columnToCompare) {
+                            $query
+                                ->selectRaw(1)
+                                ->from('institutions')
+                                ->whereColumn('id', '=', $columnToCompare)
+                                ->where('name', 'like', "%{$value}%");
+                        });
+                    })
+                    ->when($order === 'institution', function (EloquentBuilder $query) use ($direction) {
+                        $query
+                            ->orderByRaw($direction === 'asc' ? 'institution IS NOT NULL' : 'institution IS NULL')
+                            ->orderBy('institution', $direction);
+                    });
+            },
+            accepted_args: 5
         );
     }
 

--- a/src/Controllers/InstitutionsController.php
+++ b/src/Controllers/InstitutionsController.php
@@ -94,6 +94,8 @@ class InstitutionsController extends BaseController
             default => null,
         };
 
+        do_action('pressbooks_multi_institution_deleted_institution', $items);
+
         apply_filters('pb_institutional_after_delete', [], $institutionalManagerIds);
 
         return [

--- a/src/Services/MenuManager.php
+++ b/src/Services/MenuManager.php
@@ -75,6 +75,8 @@ class MenuManager
                 echo app(AssignBooksController::class)->index();
             }
         );
+
+        apply_filters('pressbooks-multi-institution-add-menu', $this->slug);
     }
 
     /**

--- a/src/Services/MenuManager.php
+++ b/src/Services/MenuManager.php
@@ -76,7 +76,7 @@ class MenuManager
             }
         );
 
-        apply_filters('pressbooks-multi-institution-add-menu', $this->slug);
+        apply_filters('pressbooks_multi_institution_add_menu', $this->slug);
     }
 
     /**

--- a/src/Services/MenuManager.php
+++ b/src/Services/MenuManager.php
@@ -76,7 +76,7 @@ class MenuManager
             }
         );
 
-        apply_filters('pressbooks_multi_institution_add_menu', $this->slug);
+        do_action('pressbooks_multi_institution_add_menu', $this->slug);
     }
 
     /**

--- a/tests/Feature/BootstrapTest.php
+++ b/tests/Feature/BootstrapTest.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace Tests\Feature;
+
+use PressbooksMultiInstitution\Models\Institution;
+use Tests\TestCase;
+use Tests\Traits\CreatesModels;
+
+class BootstrapTest extends TestCase
+{
+    use CreatesModels;
+
+    /**
+     * @test
+     */
+    public function it_registers_get_institution_dropdown_hook(): void
+    {
+        global $wp_filter;
+
+        $this->assertArrayHasKey('pressbooks_get_institution_dropdown', $wp_filter);
+    }
+
+    /**
+     * @test
+     */
+    public function it_registers_get_institution_by_id_hook(): void
+    {
+        global $wp_filter;
+
+        $this->assertArrayHasKey('pressbooks_get_institution_by_id', $wp_filter);
+    }
+
+
+    /**
+     * @test
+     */
+    public function it_registers_append_institution_to_query_hook(): void
+    {
+        global $wp_filter;
+
+        $this->assertArrayHasKey('pressbooks_append_institution_to_query', $wp_filter);
+    }
+
+    /**
+     * @test
+     */
+    public function it_retrieves_a_dropdown_list_of_institutions(): void
+    {
+        $first = $this->createInstitution([
+            'name' => 'Fake Institution',
+        ]);
+
+        $second = $this->createInstitution([
+            'name' => 'Another Fake Institution',
+        ]);
+
+        $response = apply_filters('pressbooks_get_institution_dropdown', []);
+
+        $this->assertEquals([
+            0 => 'Unassigned',
+            $second->id => $second->name,
+            $first->id => $first->name,
+        ], $response);
+    }
+
+    /**
+     * @test
+     */
+    public function it_retrieves_an_empty_dropdown_list_of_institutions_when_no_institutions_are_registered(): void
+    {
+        $response = apply_filters('pressbooks_get_institution_dropdown', []);
+
+        $this->assertEquals([
+            0 => 'Unassigned',
+        ], $response);
+    }
+
+    /**
+     * @test
+     */
+    public function it_retrieves_the_institution_id(): void
+    {
+        $institution = $this->createInstitution([
+            'name' => 'Fake Institution',
+        ]);
+
+        $id = apply_filters('pressbooks_get_institution_by_id', null, $institution->id);
+
+        $this->assertEquals($institution->id, $id);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_default_value_if_institution_does_not_exist(): void
+    {
+        $id = apply_filters('pressbooks_get_institution_by_id', null, 999);
+
+        $this->assertNull($id);
+    }
+
+    /**
+     * @test
+     */
+    public function it_appends_institution_subquery_to_query(): void
+    {
+        $query = Institution::query();
+
+        $columnToCompare = 'column_name';
+
+        $this->assertStringNotContainsString('select `name` from `wptests_institutions` where `id` = `column_name`', $query->toSql());
+
+        apply_filters('pressbooks_append_institution_to_query', $query, $columnToCompare);
+
+        $this->assertStringContainsString('select `name` from `wptests_institutions` where `id` = `column_name`', $query->toSql());
+    }
+
+    /**
+     * @test
+     */
+    public function it_appends_exists_clause_when_searching(): void
+    {
+        $query = Institution::query();
+
+        $columnToCompare = 'column_name';
+
+        $searchValue = 'foo';
+
+        $this->assertStringNotContainsString('exists (select 1 from `wptests_institutions` where `id` = `column_name` and `name` like ?)', $query->toSql());
+
+        $this->assertEmpty($query->getBindings());
+
+        apply_filters('pressbooks_append_institution_to_query', $query, $columnToCompare, $searchValue);
+
+        $this->assertStringContainsString('exists (select 1 from `wptests_institutions` where `id` = `column_name` and `name` like ?)', $query->toSql());
+
+        $this->assertEquals([
+            '%foo%'
+        ], $query->getBindings());
+    }
+
+    /**
+     * @test
+     */
+    public function it_appends_order_by_clause_ascending_when_sorting_by_institution(): void
+    {
+        $query = Institution::query();
+
+        $columnToCompare = 'column_name';
+
+        $sort = 'institution';
+
+        $direction = 'asc';
+
+        $this->assertStringNotContainsString('order by institution IS NOT NULL, `institution` asc', $query->toSql());
+
+        apply_filters('pressbooks_append_institution_to_query', $query, $columnToCompare, '', $sort, $direction);
+
+        $this->assertStringContainsString('order by institution IS NOT NULL, `institution` asc', $query->toSql());
+    }
+
+    /**
+     * @test
+     */
+    public function it_appends_order_by_clause_descending_when_sorting_by_institution(): void
+    {
+        $query = Institution::query();
+
+        $columnToCompare = 'column_name';
+
+        $sort = 'institution';
+
+        $direction = 'desc';
+
+        $this->assertStringNotContainsString('order by institution IS NULL, `institution` desc', $query->toSql());
+
+        apply_filters('pressbooks_append_institution_to_query', $query, $columnToCompare, '', $sort, $direction);
+
+        $this->assertStringContainsString('order by institution IS NULL, `institution` desc', $query->toSql());
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_append_order_by_clause_when_sorting_by_a_different_field(): void
+    {
+        $query = Institution::query();
+
+        $columnToCompare = 'column_name';
+
+        $sort = 'foo';
+
+        $direction = 'asc';
+
+        $this->assertStringNotContainsString('order by', $query->toSql());
+
+        apply_filters('pressbooks_append_institution_to_query', $query, $columnToCompare, '', $sort, $direction);
+
+        $this->assertStringNotContainsString('order by', $query->toSql());
+    }
+}

--- a/tests/Feature/BootstrapTest.php
+++ b/tests/Feature/BootstrapTest.php
@@ -110,7 +110,7 @@ class BootstrapTest extends TestCase
 
         $this->assertStringNotContainsString('select `name` from `wptests_institutions` where `id` = `column_name`', $query->toSql());
 
-        apply_filters('pressbooks_append_institution_to_query', $query, $columnToCompare);
+        $query = apply_filters('pressbooks_append_institution_to_query', $query, $columnToCompare);
 
         $this->assertStringContainsString('select `name` from `wptests_institutions` where `id` = `column_name`', $query->toSql());
     }
@@ -130,7 +130,7 @@ class BootstrapTest extends TestCase
 
         $this->assertEmpty($query->getBindings());
 
-        apply_filters('pressbooks_append_institution_to_query', $query, $columnToCompare, $searchValue);
+        $query = apply_filters('pressbooks_append_institution_to_query', $query, $columnToCompare, $searchValue);
 
         $this->assertStringContainsString('exists (select 1 from `wptests_institutions` where `id` = `column_name` and `name` like ?)', $query->toSql());
 
@@ -154,7 +154,7 @@ class BootstrapTest extends TestCase
 
         $this->assertStringNotContainsString('order by institution IS NOT NULL, `institution` asc', $query->toSql());
 
-        apply_filters('pressbooks_append_institution_to_query', $query, $columnToCompare, '', $sort, $direction);
+        $query = apply_filters('pressbooks_append_institution_to_query', $query, $columnToCompare, '', $sort, $direction);
 
         $this->assertStringContainsString('order by institution IS NOT NULL, `institution` asc', $query->toSql());
     }
@@ -174,7 +174,7 @@ class BootstrapTest extends TestCase
 
         $this->assertStringNotContainsString('order by institution IS NULL, `institution` desc', $query->toSql());
 
-        apply_filters('pressbooks_append_institution_to_query', $query, $columnToCompare, '', $sort, $direction);
+        $query = apply_filters('pressbooks_append_institution_to_query', $query, $columnToCompare, '', $sort, $direction);
 
         $this->assertStringContainsString('order by institution IS NULL, `institution` desc', $query->toSql());
     }
@@ -194,7 +194,7 @@ class BootstrapTest extends TestCase
 
         $this->assertStringNotContainsString('order by', $query->toSql());
 
-        apply_filters('pressbooks_append_institution_to_query', $query, $columnToCompare, '', $sort, $direction);
+        $query = apply_filters('pressbooks_append_institution_to_query', $query, $columnToCompare, '', $sort, $direction);
 
         $this->assertStringNotContainsString('order by', $query->toSql());
     }


### PR DESCRIPTION
Issue pressbooks/pressbooks-lti#231. Accompanies pressbooks/pressbooks-lti#237.

This PR adds new hooks to support associating an LTI Platform with an institution.

1. It calls a new `pressbooks_multi_institution_add_menu` action allowing other plugins to hook into it and append additional sub-menus by doing something like below:

```php
add_action('pressbooks_multi_institution_add_menu', function (string $slug) {
    add_submenu_page(
        parent_slug: $slug,
        // ...
    );
});
```

The action passes a single argument which is the parent menu identifier.

2. It includes a new `pressbooks_get_institution_by_id` filter allowing plugins to validate if an institution id exists. If the institution does not exist it returns a `$default` value. The filter accepts two arguments: the `default` value and the `id` to be verified.

3. It includes a new `pressbooks_get_institution_dropdown` filter which returns an array of the institutions to be used in a dropdown (most common scenario). It returns the list in the following format:

```php
[
  0 => "Unassigned"
  2 => "Institution"
  1 => "University"
  // ...
]
``` 

4. It includes a new `pressbooks_multi_institution_deleted_institution` action which is called whenever one or more institutions are deleted. It passes the ids of the institutions as an argument.

```php
add_action('pressbooks_multi_institution_deleted_institution', function (array $ids) {
    // handle deleted ids here...
```

5. Finally, it includes a new `pressbooks_append_institution_to_query` filter which hooks into a query and modifies it to include the institution information. It accepts five arguments, being:

- `$query`: the Eloquent query to modify
- `$columnToCompare`: the column to compare against the institution id
- `$search`: the search string -- useful to add additional filters to the query
- `$order`: the column name to be used to sort the query
- `$direction`: the direction to sort the query `asc|desc`

**How to test**

If this plugin is active without the LTI plugin being active, no changes should happen and the plugin should behave as before. 
If the LTI plugin is active, please follow the tests steps on pressbooks/pressbooks-lti#237.

