### PR TITLE
fix: add default value parameter to hook

### DIFF
--- a/languages/pressbooks-multi-institution.pot
+++ b/languages/pressbooks-multi-institution.pot
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 Pressbooks (Book Oven Inc.)
+# Copyright (C) 2025 Pressbooks (Book Oven Inc.)
 # This file is distributed under the GPL v3 or later.
 msgid ""
 msgstr ""
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2024-12-18T15:00:46+00:00\n"
+"POT-Creation-Date: 2025-01-02T16:53:32+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.11.0\n"
 "X-Domain: pressbooks-multi-institution\n"
@@ -39,7 +39,7 @@ msgstr ""
 msgid "https://pressbooks.org"
 msgstr ""
 
-#: src/Bootstrap.php:103
+#: src/Bootstrap.php:104
 #: src/Traits/OverridesBulkActions.php:14
 #: src/Views/AssignUsersTable.php:74
 #: src/Views/BaseInstitutionList.php:108
@@ -50,7 +50,7 @@ msgstr ""
 msgid "Unassigned"
 msgstr ""
 
-#: src/Bootstrap.php:144
+#: src/Bootstrap.php:145
 msgid "Are you sure you want to delete the selected institutions?"
 msgstr ""
 

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -81,7 +81,8 @@ final class Bootstrap
     {
         add_filter(
             hook_name: 'pressbooks_get_institution_id',
-            callback: fn (int $userId) => InstitutionUser::query()->where('user_id', $userId)->value('institution_id') ?? 0
+            callback: fn (mixed $default, int $userId) => InstitutionUser::query()->where('user_id', $userId)->value('institution_id') ?? 0,
+            accepted_args: 2
         );
 
         add_filter(

--- a/tests/Feature/BootstrapTest.php
+++ b/tests/Feature/BootstrapTest.php
@@ -40,7 +40,6 @@ class BootstrapTest extends TestCase
         $this->assertArrayHasKey('pressbooks_get_institution_by_id', $wp_filter);
     }
 
-
     /**
      * @test
      */
@@ -64,7 +63,7 @@ class BootstrapTest extends TestCase
             'user_id' => $userId,
         ]);
 
-        $id = apply_filters('pressbooks_get_institution_id', $userId);
+        $id = apply_filters('pressbooks_get_institution_id', false, $userId);
 
         $this->assertEquals($institution->id, $id);
     }
@@ -78,7 +77,7 @@ class BootstrapTest extends TestCase
 
         $institution = $this->createInstitution();
 
-        $id = apply_filters('pressbooks_get_institution_id', $userId);
+        $id = apply_filters('pressbooks_get_institution_id', false, $userId);
 
         $this->assertEquals(0, $id);
     }


### PR DESCRIPTION
Issue pressbooks/pressbooks-lti#232. Accompanies pressbooks/pressbooks-lti#251.

This PR adds an additional parameter to the hook which is used as the default value in scenarios where the hook is not set at runtime.