### PR TITLE
fix: split query hooks

### DIFF
--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -108,15 +108,15 @@ final class Bootstrap
 
         add_filter(
             hook_name: 'pressbooks_append_institution_to_query',
-            callback: function (EloquentBuilder $query, string $columnToCompare, string $search = '', string $order = '', string $direction = ''): EloquentBuilder {
+            callback: function (Builder|EloquentBuilder $query, string $columnToCompare, string $search = '', string $order = '', string $direction = ''): Builder|EloquentBuilder {
                 $query
                     ->addSelect([
                         'institution' => Institution::query()
                             ->select('name')
                             ->whereColumn('id', '=', $columnToCompare)
                     ])
-                    ->when($search, function (EloquentBuilder $query, string $value) use ($columnToCompare) {
-                        $query->orWhereExists(function (Builder $query) use ($value, $columnToCompare) {
+                    ->when($search, function (Builder|EloquentBuilder $query, string $value) use ($columnToCompare) {
+                        $query->orWhereExists(function (Builder|EloquentBuilder $query) use ($value, $columnToCompare) {
                             $query
                                 ->selectRaw(1)
                                 ->from('institutions')
@@ -124,7 +124,7 @@ final class Bootstrap
                                 ->where('name', 'like', "%{$value}%");
                         });
                     })
-                    ->when($order === 'institution', function (EloquentBuilder $query) use ($direction) {
+                    ->when($order === 'institution', function (Builder|EloquentBuilder $query) use ($direction) {
                         $query
                             ->orderByRaw($direction === 'asc' ? 'institution IS NOT NULL' : 'institution IS NULL')
                             ->orderBy('institution', $direction);

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -116,7 +116,7 @@ final class Bootstrap
                             ->whereColumn('id', '=', $columnToCompare)
                     ])
                     ->when($search, function (Builder|EloquentBuilder $query, string $value) use ($columnToCompare) {
-                        $query->orWhereExists(function (Builder|EloquentBuilder $query) use ($value, $columnToCompare) {
+                        $query->whereExists(function (Builder|EloquentBuilder $query) use ($value, $columnToCompare) {
                             $query
                                 ->selectRaw(1)
                                 ->from('institutions')

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -107,23 +107,30 @@ final class Bootstrap
         );
 
         add_filter(
+            hook_name: 'pressbooks_search_by_institution',
+            callback: function (Builder|EloquentBuilder $query, string $search, string $columnToCompare): Builder|EloquentBuilder {
+                $query->orWhereExists(function (Builder|EloquentBuilder $query) use ($search, $columnToCompare) {
+                    $query
+                        ->selectRaw(1)
+                        ->from('institutions')
+                        ->whereColumn('id', '=', $columnToCompare)
+                        ->where('name', 'like', "%{$search}%");
+                });
+
+                return $query;
+            },
+            accepted_args: 3
+        );
+
+        add_filter(
             hook_name: 'pressbooks_append_institution_to_query',
-            callback: function (Builder|EloquentBuilder $query, string $columnToCompare, string $search = '', string $order = '', string $direction = ''): Builder|EloquentBuilder {
+            callback: function (Builder|EloquentBuilder $query, string $columnToCompare, string $order = '', string $direction = ''): Builder|EloquentBuilder {
                 $query
                     ->addSelect([
                         'institution' => Institution::query()
                             ->select('name')
                             ->whereColumn('id', '=', $columnToCompare)
                     ])
-                    ->when($search, function (Builder|EloquentBuilder $query, string $value) use ($columnToCompare) {
-                        $query->whereExists(function (Builder|EloquentBuilder $query) use ($value, $columnToCompare) {
-                            $query
-                                ->selectRaw(1)
-                                ->from('institutions')
-                                ->whereColumn('id', '=', $columnToCompare)
-                                ->where('name', 'like', "%{$value}%");
-                        });
-                    })
                     ->when($order === 'institution', function (Builder|EloquentBuilder $query) use ($direction) {
                         $query
                             ->orderByRaw($direction === 'asc' ? 'institution IS NOT NULL' : 'institution IS NULL')
@@ -132,7 +139,7 @@ final class Bootstrap
 
                 return $query;
             },
-            accepted_args: 5
+            accepted_args: 4
         );
     }
 

--- a/tests/Feature/BootstrapTest.php
+++ b/tests/Feature/BootstrapTest.php
@@ -43,6 +43,16 @@ class BootstrapTest extends TestCase
     /**
      * @test
      */
+    public function it_registers_search_by_institution_hook(): void
+    {
+        global $wp_filter;
+
+        $this->assertArrayHasKey('pressbooks_search_by_institution', $wp_filter);
+    }
+
+    /**
+     * @test
+     */
     public function it_registers_append_institution_to_query_hook(): void
     {
         global $wp_filter;
@@ -159,7 +169,7 @@ class BootstrapTest extends TestCase
     /**
      * @test
      */
-    public function it_appends_exists_clause_when_searching(): void
+    public function it_adds_exist_clause_to_query(): void
     {
         $query = Institution::query();
 
@@ -171,12 +181,36 @@ class BootstrapTest extends TestCase
 
         $this->assertEmpty($query->getBindings());
 
-        $query = apply_filters('pressbooks_append_institution_to_query', $query, $columnToCompare, $searchValue);
+        $query = apply_filters('pressbooks_search_by_institution', $query, $searchValue, $columnToCompare);
 
-        $this->assertStringContainsString('exists (select 1 from `wptests_institutions` where `id` = `column_name` and `name` like ?)', $query->toSql());
+        $this->assertStringContainsString('where exists (select 1 from `wptests_institutions` where `id` = `column_name` and `name` like ?)', $query->toSql());
 
         $this->assertEquals([
             '%foo%'
+        ], $query->getBindings());
+    }
+
+    /**
+     * @test
+     */
+    public function it_adds_exist_clause_to_nested_queries(): void
+    {
+        $columnToCompare = 'column_name';
+
+        $searchValue = 'foo';
+
+        $query = Institution::query()
+            ->where(function ($query) use ($searchValue, $columnToCompare) {
+                $query->where('name', 'like', "%$searchValue%");
+
+                apply_filters('pressbooks_search_by_institution', $query, $searchValue, $columnToCompare);
+            });
+
+        $this->assertStringContainsString('or exists (select 1 from `wptests_institutions` where `id` = `column_name` and `name` like ?)', $query->toSql());
+
+        $this->assertEquals([
+            '%foo%',
+            '%foo%',
         ], $query->getBindings());
     }
 
@@ -195,7 +229,7 @@ class BootstrapTest extends TestCase
 
         $this->assertStringNotContainsString('order by institution IS NOT NULL, `institution` asc', $query->toSql());
 
-        $query = apply_filters('pressbooks_append_institution_to_query', $query, $columnToCompare, '', $sort, $direction);
+        $query = apply_filters('pressbooks_append_institution_to_query', $query, $columnToCompare, $sort, $direction);
 
         $this->assertStringContainsString('order by institution IS NOT NULL, `institution` asc', $query->toSql());
     }
@@ -215,7 +249,7 @@ class BootstrapTest extends TestCase
 
         $this->assertStringNotContainsString('order by institution IS NULL, `institution` desc', $query->toSql());
 
-        $query = apply_filters('pressbooks_append_institution_to_query', $query, $columnToCompare, '', $sort, $direction);
+        $query = apply_filters('pressbooks_append_institution_to_query', $query, $columnToCompare, $sort, $direction);
 
         $this->assertStringContainsString('order by institution IS NULL, `institution` desc', $query->toSql());
     }
@@ -235,7 +269,7 @@ class BootstrapTest extends TestCase
 
         $this->assertStringNotContainsString('order by', $query->toSql());
 
-        $query = apply_filters('pressbooks_append_institution_to_query', $query, $columnToCompare, '', $sort, $direction);
+        $query = apply_filters('pressbooks_append_institution_to_query', $query, $columnToCompare, $sort, $direction);
 
         $this->assertStringNotContainsString('order by', $query->toSql());
     }


### PR DESCRIPTION
Issue https://github.com/pressbooks/pressbooks-results-for-lms/issues/299. Accompanies https://github.com/pressbooks/pressbooks-lti/pull/281.

This PR splits the `pressbooks_append_institution_to_query` hook into two separate ones. A new `pressbooks_search_by_institution` hook was added for the solely purpose of adding a `where` search clause to the query. This is done separately so we have the flexibility of including the where clause into nested wheres in the query.

The search behavior was also removed from the `pressbooks_append_institution_to_query` hook.

In addition to that, both hooks accept `Illuminate\Database\Eloquent\Builder` and `Illuminate\Database\Query\Builder` class instances as parameter.