### PR TITLE
fix: append select in analytics users and books list instead of overriding them

### DIFF
--- a/src/Views/BaseInstitutionList.php
+++ b/src/Views/BaseInstitutionList.php
@@ -32,7 +32,7 @@ abstract class BaseInstitutionList
         ];
     }
 
-    public function appendAdditionalColumnsToQuery(): string
+    public function appendAdditionalColumnsToQuery(string $select): string
     {
         $prefix = $this->db
             ->getDatabaseManager()
@@ -50,7 +50,7 @@ abstract class BaseInstitutionList
             ->join('institutions_blogs', 'institutions.id', '=', 'institutions_blogs.institution_id')
             ->whereRaw("{$prefix}institutions_blogs.blog_id = b.blog_id");
 
-        return "({$idSubQuery->toSql()}) as institution_id, ({$nameSubQuery->toSql()}) as institution";
+        return $select . ", ({$idSubQuery->toSql()}) as institution_id, ({$nameSubQuery->toSql()}) as institution";
     }
 
     public function appendAdditionalWhereClausesToQuery(string $where): string

--- a/src/Views/UserList.php
+++ b/src/Views/UserList.php
@@ -55,7 +55,7 @@ class UserList extends BaseInstitutionList
         return $columns;
     }
 
-    public function appendAdditionalColumnsToQuery(): string
+    public function appendAdditionalColumnsToQuery(string $select): string
     {
         $prefix = $this->db
             ->getDatabaseManager()
@@ -75,7 +75,7 @@ class UserList extends BaseInstitutionList
             ->join('institutions_users', 'institutions.id', '=', 'institutions_users.institution_id')
             ->whereRaw("{$prefix}institutions_users.user_id = us.id")->limit(1);
 
-        return "({$idSubQuery->toSql()}) as institution_id, ({$nameSubQuery->toSql()}) as institution";
+        return $select . ", ({$idSubQuery->toSql()}) as institution_id, ({$nameSubQuery->toSql()}) as institution";
     }
 
 }

--- a/tests/Feature/Views/BookListTest.php
+++ b/tests/Feature/Views/BookListTest.php
@@ -129,7 +129,7 @@ class BookListTest extends TestCase
     {
         Container::get(BookList::class)->init();
 
-        $expected = '(select `wptests_institutions`.`id` from `wptests_institutions` inner join `wptests_institutions_blogs` on `wptests_institutions`.`id` = `wptests_institutions_blogs`.`institution_id` where wptests_institutions_blogs.blog_id = b.blog_id) as institution_id, (select `wptests_institutions`.`name` from `wptests_institutions` inner join `wptests_institutions_blogs` on `wptests_institutions`.`id` = `wptests_institutions_blogs`.`institution_id` where wptests_institutions_blogs.blog_id = b.blog_id) as institution';
+        $expected = ', (select `wptests_institutions`.`id` from `wptests_institutions` inner join `wptests_institutions_blogs` on `wptests_institutions`.`id` = `wptests_institutions_blogs`.`institution_id` where wptests_institutions_blogs.blog_id = b.blog_id) as institution_id, (select `wptests_institutions`.`name` from `wptests_institutions` inner join `wptests_institutions_blogs` on `wptests_institutions`.`id` = `wptests_institutions_blogs`.`institution_id` where wptests_institutions_blogs.blog_id = b.blog_id) as institution';
 
         $this->assertEquals($expected, apply_filters('pb_network_analytics_book_list_select_clause', ''));
     }

--- a/tests/Feature/Views/UserListTest.php
+++ b/tests/Feature/Views/UserListTest.php
@@ -127,7 +127,7 @@ class UserListTest extends TestCase
     {
         Container::get(UserList::class)->init();
 
-        $expected = "(select `wptests_institutions`.`id` from `wptests_institutions` left join `wptests_institutions_blogs` on `wptests_institutions`.`id` = `wptests_institutions_blogs`.`institution_id` inner join `wptests_institutions_users` on `wptests_institutions`.`id` = `wptests_institutions_users`.`institution_id` where wptests_institutions_users.user_id = us.id limit 1) as institution_id, (select `wptests_institutions`.`name` from `wptests_institutions` left join `wptests_institutions_blogs` on `wptests_institutions`.`id` = `wptests_institutions_blogs`.`institution_id` inner join `wptests_institutions_users` on `wptests_institutions`.`id` = `wptests_institutions_users`.`institution_id` where wptests_institutions_users.user_id = us.id limit 1) as institution";
+        $expected = ", (select `wptests_institutions`.`id` from `wptests_institutions` left join `wptests_institutions_blogs` on `wptests_institutions`.`id` = `wptests_institutions_blogs`.`institution_id` inner join `wptests_institutions_users` on `wptests_institutions`.`id` = `wptests_institutions_users`.`institution_id` where wptests_institutions_users.user_id = us.id limit 1) as institution_id, (select `wptests_institutions`.`name` from `wptests_institutions` left join `wptests_institutions_blogs` on `wptests_institutions`.`id` = `wptests_institutions_blogs`.`institution_id` inner join `wptests_institutions_users` on `wptests_institutions`.`id` = `wptests_institutions_users`.`institution_id` where wptests_institutions_users.user_id = us.id limit 1) as institution";
         $this->assertEquals($expected, apply_filters('pb_network_analytics_user_list_select_clause', ''));
     }
 


### PR DESCRIPTION
Issue: https://github.com/pressbooks/pressbooks-vip/issues/428

This pull request includes changes to the `appendAdditionalColumnsToQuery` method in multiple files to accept a `string $select` parameter, and updates related test cases accordingly. This change allows other plugins using the `pb_network_analytics_user_list_where_clause` and `pb_network_analytics_book_list_where_clause` hooks as well.

>[!WARNING]
> This PR requires: https://github.com/pressbooks/pressbooks-network-analytics/pull/394

Changes to method signatures:

* [`src/Views/BaseInstitutionList.php`](diffhunk://#diff-5366ffd9faebf6c09503c28a57632125457caa651408c6d912f988046c31867cL35-R35): Modified the `appendAdditionalColumnsToQuery` method to accept a `string $select` parameter and updated its return statement to include this parameter. [[1]](diffhunk://#diff-5366ffd9faebf6c09503c28a57632125457caa651408c6d912f988046c31867cL35-R35) [[2]](diffhunk://#diff-5366ffd9faebf6c09503c28a57632125457caa651408c6d912f988046c31867cL53-R53)
* [`src/Views/UserList.php`](diffhunk://#diff-95bf2e2f63154d8b8da03f7c6b72bb4184b2f10bc68924cdec8cd77c539c393fL58-R58): Modified the `appendAdditionalColumnsToQuery` method to accept a `string $select` parameter and updated its return statement to include this parameter. [[1]](diffhunk://#diff-95bf2e2f63154d8b8da03f7c6b72bb4184b2f10bc68924cdec8cd77c539c393fL58-R58) [[2]](diffhunk://#diff-95bf2e2f63154d8b8da03f7c6b72bb4184b2f10bc68924cdec8cd77c539c393fL78-R78)

Updates to test cases:

* [`tests/Feature/Views/BookListTest.php`](diffhunk://#diff-d1bddc10999d14970049591fa0d0fa89e9df4eff15eb708b8d04db528a2f065bL132-R132): Updated the expected value in the `it_returns_additional_select_clauses_to_the_query` test case to include the `select` clause.
* [`tests/Feature/Views/UserListTest.php`](diffhunk://#diff-eb5e37e9b49b7036a5d90e2d17ea0bf9eda6b9710fd6f6f1438dafbd80df808dL130-R130): Updated the expected value in the `it_returns_additional_select_clauses_to_the_query` test case to include the `select` clause.