### PR TITLE
fix: revert pressbooks table changes

### DIFF
--- a/src/Views/AssignBooksTable.php
+++ b/src/Views/AssignBooksTable.php
@@ -6,7 +6,6 @@ use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Capsule\Manager;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Str;
-use Pressbooks\Admin\PressbooksTable;
 use PressbooksMultiInstitution\Traits\OverridesBulkActions;
 use WP_List_Table;
 
@@ -16,7 +15,6 @@ use function Pressbooks\Sanitize\sanitize_string;
 class AssignBooksTable extends WP_List_Table
 {
     use OverridesBulkActions;
-    use PressbooksTable;
 
     protected int $paginationSize = 50;
 

--- a/src/Views/AssignUsersTable.php
+++ b/src/Views/AssignUsersTable.php
@@ -3,14 +3,12 @@
 namespace PressbooksMultiInstitution\Views;
 
 use Illuminate\Database\Query\Builder;
-use Pressbooks\Admin\PressbooksTable;
 use PressbooksMultiInstitution\Traits\OverridesBulkActions;
 use WP_List_Table;
 
 class AssignUsersTable extends WP_List_Table
 {
     use OverridesBulkActions;
-    use PressbooksTable;
 
     protected int $paginationSize = 50;
 


### PR DESCRIPTION
This PR reverts: https://github.com/pressbooks/pressbooks-multi-institution/pull/254