### PR TITLE
fix: pot workflow

### DIFF
--- a/.github/workflows/update-pot.yml
+++ b/.github/workflows/update-pot.yml
@@ -18,4 +18,3 @@ jobs:
       slug: "pressbooks-multi-institution"
       package_name: "Pressbooks Shared Network"
       headers: '{"Report-Msgid-Bugs-To": "https://github.com/pressbooks/pressbooks-multi-institution/issues"}'
-      pull_request_number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Remove unrequired parameter on push triggers