### PR TITLE
fix: release notes dashboard display

### DIFF
--- a/resources/views/dashboard/institutional.blade.php
+++ b/resources/views/dashboard/institutional.blade.php
@@ -1,64 +1,69 @@
 <div class="wrap">
 	<div class="pb-dashboard-row">
-			<div class="pb-dashboard-grid">
-				<div class="pb-dashboard-panel">
-					<div class="pb-dashboard-content pb-institution-welcome-content">
-						<h1 class="screen-reader-text">{{ __('Institutional Manager Dashboard', 'pressbooks-multi-institution')  }}</h1>
-						<h2>
-							{{ __( 'Welcome to', 'pressbooks-multi-institution' ) }}
-							<span class="network-title">{!! $network_name !!}</span>
-						</h2>
-						<a class="visit-homepage" href="{{ $network_url }}">
-							{{ __( 'Visit network homepage', 'pressbooks-multi-institution' ) }}
-						</a>
-						<p>
-							{!! sprintf( __( '%s has %s books and %s users. ', 'pressbooks-multi-institution' ), "{$institution_name}","<strong>{$total_books}</strong>", "<strong>{$total_users}</strong>" ) !!}
-						</p>
-					</div>
+		<div class="pb-dashboard-grid">
+			<div class="pb-dashboard-panel">
+				<div class="pb-dashboard-content pb-institution-welcome-content">
+					<h1 class="screen-reader-text">{{ __('Institutional Manager Dashboard', 'pressbooks-multi-institution')  }}</h1>
+					<h2>
+						{{ __( 'Welcome to', 'pressbooks-multi-institution' ) }}
+						<span class="network-title">{!! $network_name !!}</span>
+					</h2>
+					<a class="visit-homepage" href="{{ $network_url }}">
+						{{ __( 'Visit network homepage', 'pressbooks-multi-institution' ) }}
+					</a>
+					<p>
+						{!! sprintf( __( '%s has %s books and %s users. ', 'pressbooks-multi-institution' ), "{$institution_name}","<strong>{$total_books}</strong>", "<strong>{$total_users}</strong>" ) !!}
+					</p>
 				</div>
-				<div class="pb-dashboard-panel">
-					<div class="pb-dashboard-content">
-						<h2>{{ __( 'Administer', 'pressbooks-multi-institution' )}} {{$institution_name}}</h2>
+			</div>
+			<div class="pb-dashboard-panel">
+				<div class="pb-dashboard-content">
+					<h2>{{ __( 'Administer', 'pressbooks-multi-institution' )}} {{$institution_name}}</h2>
 
-						<div class="pb-dashboard-flex">
-							<img
-								class="pb-dashboard-flex-image"
-								src="{{ PB_PLUGIN_URL . "assets/dist/images/pb-network-settings.png" }}"
-								alt="{{ __( 'Administer network art', 'pressbooks-multi-institution' ) }}"
-							/>
+					<div class="pb-dashboard-flex">
+						<img
+							class="pb-dashboard-flex-image"
+							src="{{ PB_PLUGIN_URL . "assets/dist/images/pb-network-settings.png" }}"
+							alt="{{ __( 'Administer network art', 'pressbooks-multi-institution' ) }}"
+						/>
 
-							<ul class="actions">
-								<li>
-									<a
-										href="{!! network_admin_url( $network_analytics_active ? 'sites.php?page=pb_network_analytics_booklist' : 'sites.php' ) !!}"
-									>
-										<i class="pb-heroicons pb-heroicons-outline_book-open" aria-hidden="true"></i>
-										<span>{{ __( 'View book list', 'pressbooks-multi-institution' ) }}</span>
-									</a>
-								</li>
-								<li>
-									<a
-										href="{!! network_admin_url( $network_analytics_active ? 'users.php?page=pb_network_analytics_userlist' : 'users.php' ) !!}"
-									>
-										<i class="pb-heroicons pb-heroicons-outline_users" aria-hidden="true"></i>
-										<span>{{ __( 'View user list', 'pressbooks-multi-institution' ) }}</span>
-									</a>
-								</li>
-								@if( $network_analytics_active )
+						<ul class="actions">
+							<li>
+								<a
+									href="{!! network_admin_url( $network_analytics_active ? 'sites.php?page=pb_network_analytics_booklist' : 'sites.php' ) !!}"
+								>
+									<i class="pb-heroicons pb-heroicons-outline_book-open" aria-hidden="true"></i>
+									<span>{{ __( 'View book list', 'pressbooks-multi-institution' ) }}</span>
+								</a>
+							</li>
+							<li>
+								<a
+									href="{!! network_admin_url( $network_analytics_active ? 'users.php?page=pb_network_analytics_userlist' : 'users.php' ) !!}"
+								>
+									<i class="pb-heroicons pb-heroicons-outline_users" aria-hidden="true"></i>
+									<span>{{ __( 'View user list', 'pressbooks-multi-institution' ) }}</span>
+								</a>
+							</li>
+							@if( $network_analytics_active )
 								<li>
 									<a
 										href="{!! network_admin_url( 'admin.php?page=pb_network_analytics_admin' ) !!}"
 									>
-										<i class="pb-heroicons pb-heroicons-outline_presentation-char-bar" aria-hidden="true"></i>
+										<i class="pb-heroicons pb-heroicons-outline_presentation-char-bar"
+										   aria-hidden="true"></i>
 										<span>{{ __( 'Explore Stats', 'pressbooks-multi-institution' ) }}</span>
 									</a>
 								</li>
-								@endif
-							</ul>
-						</div>
+							@endif
+						</ul>
 					</div>
 				</div>
 			</div>
 		</div>
-	@include('admin.dashboard.support')
+	</div>
+	<div class="pb-dashboard-row">
+		<div class="pb-dashboard-grid">
+			@include('admin.dashboard.support', ['updates' => $updates])
+		</div>
+	</div>
 </div>

--- a/src/Actions/InstitutionalManagerDashboard.php
+++ b/src/Actions/InstitutionalManagerDashboard.php
@@ -12,7 +12,6 @@ class InstitutionalManagerDashboard extends Dashboard
 
     public function hooks(): void
     {
-        parent::hooks();
         add_action('load-index.php', [$this, 'redirect'], 1001);
         add_action('admin_menu', [$this, 'removeDefaultPage']);
         add_action('admin_menu', [$this, 'addNewPage']);

--- a/src/Actions/InstitutionalManagerDashboard.php
+++ b/src/Actions/InstitutionalManagerDashboard.php
@@ -12,10 +12,12 @@ class InstitutionalManagerDashboard extends Dashboard
 
     public function hooks(): void
     {
+        parent::hooks();
         add_action('load-index.php', [$this, 'redirect'], 1001);
         add_action('admin_menu', [$this, 'removeDefaultPage']);
         add_action('admin_menu', [$this, 'addNewPage']);
         add_action('admin_init', [$this, 'superAdminSafeRedirect'], 1);
+        $this->fetchUpdates();
     }
 
     public function render(): void
@@ -28,7 +30,11 @@ class InstitutionalManagerDashboard extends Dashboard
                 'institution_name' => apply_filters('pb_institution', [])['name'],
                 'total_books' => count(apply_filters('pb_institutional_books', [])),
                 'total_users' => count(apply_filters('pb_institutional_users', [])),
-                'network_analytics_active' => is_plugin_active('pressbooks-network-analytics/pressbooks-network-analytics.php')
+                'network_analytics_active' => is_plugin_active('pressbooks-network-analytics/pressbooks-network-analytics.php'),
+                'updates' => [
+                    'text' => $this->recentUpdates['content'] ?? '',
+                    'url' => isset($this->recentUpdates['post_id']) ? "{$this->recentUpdates['domain']}?p={$this->recentUpdates['post_id']}" : null,
+                ],
             ]
         );
     }


### PR DESCRIPTION
This pull request introduces updates to the institutional dashboard in Pressbooks, focusing on enhancing the display of recent updates and improving the structure of the dashboard layout. The most important changes include adjustments to the Blade template for better layout organization, integration of recent updates into the dashboard, and modifications to the backend logic to fetch and display these updates.

### Dashboard layout improvements:
* [`resources/views/dashboard/institutional.blade.php`](diffhunk://#diff-01816d55452dc449d3d87c8291ad6a1be80f0e3eda9d0c74575295ce8496022eL63-R68): Refactored the inclusion of the support section into a new grid layout for improved visual structure.

### Integration of recent updates:
* [`src/Actions/InstitutionalManagerDashboard.php`](diffhunk://#diff-11b7b801a2606cff16478fe86da8bd8c0c52b40170cd7a0aa91164902b2b3841L31-R36): Added a new `updates` key to the data passed to the dashboard view, including the text and URL for recent updates.
* [`src/Actions/InstitutionalManagerDashboard.php`](diffhunk://#diff-11b7b801a2606cff16478fe86da8bd8c0c52b40170cd7a0aa91164902b2b3841R19): Introduced a call to `fetchUpdates()` in the `hooks()` method to ensure updates are retrieved when the dashboard is rendered.

### Minor code formatting:
* [`resources/views/dashboard/institutional.blade.php`](diffhunk://#diff-01816d55452dc449d3d87c8291ad6a1be80f0e3eda9d0c74575295ce8496022eL52-R53): Adjusted formatting for the `<i>` tag in the "Explore Stats" section for improved readability.