### PR TITLE
fix: respect sorters for ordering users & books list

### DIFF
--- a/src/Views/BaseInstitutionList.php
+++ b/src/Views/BaseInstitutionList.php
@@ -101,14 +101,22 @@ abstract class BaseInstitutionList
         return $where;
     }
 
-    public function filterInstitutionListItems($bookList): array
+    public function filterInstitutionListItems(array $list, array $sorters): array
     {
-        return array_map(function (\stdClass $item) {
+        $list = array_map(function (\stdClass $item) {
             unset($item->institution_id);
             $item->institution = $item->institution ?? __('Unassigned', 'pressbooks-multi-institution');
             return $item;
-        }, $bookList);
+        }, $list);
+
+        if (! empty($sorters)) {
+            $list = wp_list_sort($list, $sorters);
+        }
+
+        return $list;
     }
+
     abstract public function addColumns(array $columns): array;
+
     abstract public function getCustomTexts(array $texts): array;
 }

--- a/src/Views/BookList.php
+++ b/src/Views/BookList.php
@@ -17,7 +17,7 @@ class BookList extends BaseInstitutionList
         add_filter('pb_network_analytics_book_list_select_clause', [$this, 'appendAdditionalColumnsToQuery']);
         add_filter('pb_network_analytics_book_list_where_clause', [$this, 'appendAdditionalWhereClausesToQuery']);
         add_filter('pb_network_analytics_book_list_filter', [$this, 'addFilters']);
-        add_filter('pb_network_analytics_book_list_fields', [$this, 'filterInstitutionListItems']);
+        add_filter('pb_network_analytics_book_list_fields', [$this, 'filterInstitutionListItems'], 2, 10);
     }
 
     public function addColumns(array $columns): array

--- a/src/Views/UserList.php
+++ b/src/Views/UserList.php
@@ -15,7 +15,7 @@ class UserList extends BaseInstitutionList
         add_filter('pb_network_analytics_user_list_select_clause', [$this, 'appendAdditionalColumnsToQuery']);
         add_filter('pb_network_analytics_user_list_where_clause', [$this, 'appendAdditionalWhereClausesToQuery']);
         add_filter('pb_network_analytics_user_list_filter', [$this, 'addFilters']);
-        add_filter('pb_network_analytics_user_list_fields', [$this, 'filterInstitutionListItems']);
+        add_filter('pb_network_analytics_user_list_fields', [$this, 'filterInstitutionListItems'], 2, 10);
     }
     public function getCustomTexts(array $texts): array
     {


### PR DESCRIPTION
Fixes: https://github.com/pressbooks/pressbooks-multi-institution/issues/278

Requires: https://github.com/pressbooks/pressbooks-network-analytics/pull/408

This pull request refactors the way institution list items are filtered and sorted in the analytics views. The main change is to enhance the flexibility of the `filterInstitutionListItems` method by allowing sorting, and to update the relevant filters to support this new method signature.

**Refactoring and sorting improvements:**

* Updated the signature of `filterInstitutionListItems` in `BaseInstitutionList.php` to accept both the list and sorters, and added sorting logic using `wp_list_sort` for more flexible data handling.

**Integration with analytics views:**

* Modified the filter hooks in `BookList.php` and `UserList.php` to pass the correct arguments to `filterInstitutionListItems`, ensuring compatibility with the new method signature and sorting capability. [[1]](diffhunk://#diff-c49034cb387060ed66cade30f5febce8de3a649d7538be64163e1a531b02d21eL20-R20) [[2]](diffhunk://#diff-95bf2e2f63154d8b8da03f7c6b72bb4184b2f10bc68924cdec8cd77c539c393fL18-R18)