### PR TITLE
fix: unnasigned sorting in books list

### DIFF
--- a/src/Views/BaseInstitutionList.php
+++ b/src/Views/BaseInstitutionList.php
@@ -48,9 +48,12 @@ abstract class BaseInstitutionList
             ->table('institutions')
             ->select('institutions.name')
             ->join('institutions_blogs', 'institutions.id', '=', 'institutions_blogs.institution_id')
-            ->whereRaw("{$prefix}institutions_blogs.blog_id = b.blog_id");
+            ->whereRaw("{$prefix}institutions_blogs.blog_id = b.blog_id")
+            ->limit(1);
 
-        return $select . ", ({$idSubQuery->toSql()}) as institution_id, ({$nameSubQuery->toSql()}) as institution";
+        $unassigned = $this->db->getConnection()->getPdo()->quote(__('Unassigned', 'pressbooks-multi-institution'));
+
+        return $select . ", ({$idSubQuery->toSql()}) as institution_id" . ", (COALESCE(({$nameSubQuery->toSql()}), {$unassigned})) as institution";
     }
 
     public function appendAdditionalWhereClausesToQuery(string $where): string

--- a/tests/Feature/Views/BookListTest.php
+++ b/tests/Feature/Views/BookListTest.php
@@ -129,7 +129,7 @@ class BookListTest extends TestCase
     {
         Container::get(BookList::class)->init();
 
-        $expected = ', (select `wptests_institutions`.`id` from `wptests_institutions` inner join `wptests_institutions_blogs` on `wptests_institutions`.`id` = `wptests_institutions_blogs`.`institution_id` where wptests_institutions_blogs.blog_id = b.blog_id) as institution_id, (select `wptests_institutions`.`name` from `wptests_institutions` inner join `wptests_institutions_blogs` on `wptests_institutions`.`id` = `wptests_institutions_blogs`.`institution_id` where wptests_institutions_blogs.blog_id = b.blog_id) as institution';
+        $expected = ', (select `wptests_institutions`.`id` from `wptests_institutions` inner join `wptests_institutions_blogs` on `wptests_institutions`.`id` = `wptests_institutions_blogs`.`institution_id` where wptests_institutions_blogs.blog_id = b.blog_id) as institution_id, (COALESCE((select `wptests_institutions`.`name` from `wptests_institutions` inner join `wptests_institutions_blogs` on `wptests_institutions`.`id` = `wptests_institutions_blogs`.`institution_id` where wptests_institutions_blogs.blog_id = b.blog_id limit 1), \'' . __('Unassigned', 'pressbooks-multi-institution') . '\')) as institution';
 
         $this->assertEquals($expected, apply_filters('pb_network_analytics_book_list_select_clause', ''));
     }


### PR DESCRIPTION
Related bug: https://github.com/pressbooks/pressbooks-multi-institution/issues/278

This pull request updates the logic for selecting institution information in the `appendAdditionalColumnsToQuery` method. The main improvement is handling cases where a blog is not assigned to any institution, ensuring the output is more robust and user-friendly.

**Improvements to institution selection logic:**

* The institution name subquery now uses `COALESCE` to return a localized "Unassigned" string if no matching institution is found, improving clarity for unassigned blogs.
* Added a `LIMIT 1` clause to the institution name subquery to ensure only one result is returned, preventing potential ambiguities.

### Testing notes
- Go to Books list
- Order by institution
- Make sure order works as expected
- Go to a different page
- Make sure the order still works.