### PR TITLE
feat: add hooks for broken link checker

### DIFF
--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -9,6 +9,7 @@ use Pressbooks\Container;
 use PressbooksMultiInstitution\Actions\AssignBookToInstitution;
 use PressbooksMultiInstitution\Actions\AssignUserToInstitution;
 use PressbooksMultiInstitution\Actions\InstitutionalManagerDashboard;
+use PressbooksMultiInstitution\Integrations\ContentCheckerBooksScanTable;
 use PressbooksMultiInstitution\Models\Institution;
 use PressbooksMultiInstitution\Models\InstitutionUser;
 use PressbooksMultiInstitution\Services\InstitutionStatsService;
@@ -46,6 +47,8 @@ final class Bootstrap
         Container::getInstance()->singleton(UserList::class, fn () => new UserList(app('db')));
 
         $this->registerInstitutionHooks();
+
+        (app(ContentCheckerBooksScanTable::class))->register();
     }
 
     private function registerActions(): void

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -48,7 +48,7 @@ final class Bootstrap
 
         $this->registerInstitutionHooks();
 
-        (app(ContentCheckerBooksScanTable::class))->register();
+        app(ContentCheckerBooksScanTable::class)->register();
     }
 
     private function registerActions(): void

--- a/src/Integrations/ContentCheckerBooksScanTable.php
+++ b/src/Integrations/ContentCheckerBooksScanTable.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace PressbooksMultiInstitution\Integrations;
+
+use function PressbooksMultiInstitution\Support\get_institution_by_manager;
+
+class ContentCheckerBooksScanTable
+{
+    public function register(): void
+    {
+        add_filter('pressbooks_content_checker_book_scan_table_columns', [$this, 'addInstitutionColumn'], 10, 2);
+        add_filter('pressbooks_content_checker_book_scan_table_sortable_columns', [$this, 'addInstitutionSortableColumn'], 10, 2);
+        add_filter('pressbooks_content_checker_book_scan_table_orderby_map', [$this, 'addInstitutionOrderbySpec'], 10, 2);
+        add_filter('pressbooks_content_checker_book_scan_table_query', [$this, 'augmentBooksScanQuery'], 10, 3);
+    }
+
+    public function addInstitutionColumn(array $columns, object $table): array
+    {
+        $injected = ['institution' => __('Institution', 'pressbooks-multi-institution')];
+
+        if (array_key_exists('blog_title', $columns)) {
+            $result = [];
+            foreach ($columns as $key => $label) {
+                $result[$key] = $label;
+                if ($key === 'blog_title') {
+                    foreach ($injected as $k => $v) {
+                        $result[$k] = $v;
+                    }
+                }
+            }
+            return $result;
+        }
+
+        return $columns + $injected;
+    }
+
+    public function addInstitutionSortableColumn(array $columns, object $table): array
+    {
+        $columns['institution'] = ['institution', false];
+        return $columns;
+    }
+
+    public function addInstitutionOrderbySpec(array $map, object $table): array
+    {
+        global $wpdb;
+
+        $map['institution'] = [
+            'expression' => 'MAX(' . $wpdb->prefix . 'institutions.name)',
+        ];
+
+        return $map;
+    }
+
+    public function augmentBooksScanQuery($query, array $request, object $table)
+    {
+        global $wpdb;
+        $institutionId = get_institution_by_manager();
+
+        return $query
+            ->leftJoin('institutions_blogs', 'institutions_blogs.blog_id', '=', 'pressbooks_content_checker_reports.blog_id')
+            ->leftJoin('institutions', 'institutions.id', '=', 'institutions_blogs.institution_id')
+            ->selectRaw('MAX(' . $wpdb->prefix . 'institutions.name) AS institution')
+            ->when($institutionId !== 0, function ($q) use ($institutionId) {
+                $q->where('institutions.id', '=', $institutionId);
+            });
+    }
+}

--- a/src/Integrations/ContentCheckerBooksScanTable.php
+++ b/src/Integrations/ContentCheckerBooksScanTable.php
@@ -17,10 +17,10 @@ class ContentCheckerBooksScanTable
     public function addInstitutionColumn(array $columns): array
     {
         $injected = ['institution' => __('Institution', 'pressbooks-multi-institution')];
-        
+
         $prev_columns = array_slice($columns, 0, array_search('blog_title', array_keys($columns)) + 1, true);
         $next_columns = array_slice($columns, array_search('blog_title', array_keys($columns)) + 1, null, true);
-        
+
         return array_merge($prev_columns, $injected, $next_columns);
     }
 

--- a/src/Integrations/ContentCheckerBooksScanTable.php
+++ b/src/Integrations/ContentCheckerBooksScanTable.php
@@ -8,39 +8,29 @@ class ContentCheckerBooksScanTable
 {
     public function register(): void
     {
-        add_filter('pressbooks_content_checker_book_scan_table_columns', [$this, 'addInstitutionColumn'], 10, 2);
-        add_filter('pressbooks_content_checker_book_scan_table_sortable_columns', [$this, 'addInstitutionSortableColumn'], 10, 2);
-        add_filter('pressbooks_content_checker_book_scan_table_orderby_map', [$this, 'addInstitutionOrderbySpec'], 10, 2);
-        add_filter('pressbooks_content_checker_book_scan_table_query', [$this, 'augmentBooksScanQuery'], 10, 3);
+        add_filter('pressbooks_content_checker_book_scan_table_columns', [$this, 'addInstitutionColumn'], 10, 1);
+        add_filter('pressbooks_content_checker_book_scan_table_sortable_columns', [$this, 'addInstitutionSortableColumn'], 10, 1);
+        add_filter('pressbooks_content_checker_book_scan_table_orderby_map', [$this, 'addInstitutionOrderBySpec'], 10, 1);
+        add_filter('pressbooks_content_checker_book_scan_table_query', [$this, 'augmentBooksScanQuery'], 10, 1);
     }
 
-    public function addInstitutionColumn(array $columns, object $table): array
+    public function addInstitutionColumn(array $columns): array
     {
         $injected = ['institution' => __('Institution', 'pressbooks-multi-institution')];
-
-        if (array_key_exists('blog_title', $columns)) {
-            $result = [];
-            foreach ($columns as $key => $label) {
-                $result[$key] = $label;
-                if ($key === 'blog_title') {
-                    foreach ($injected as $k => $v) {
-                        $result[$k] = $v;
-                    }
-                }
-            }
-            return $result;
-        }
-
-        return $columns + $injected;
+        
+        $prev_columns = array_slice($columns, 0, array_search('blog_title', array_keys($columns)) + 1, true);
+        $next_columns = array_slice($columns, array_search('blog_title', array_keys($columns)) + 1, null, true);
+        
+        return array_merge($prev_columns, $injected, $next_columns);
     }
 
-    public function addInstitutionSortableColumn(array $columns, object $table): array
+    public function addInstitutionSortableColumn(array $columns): array
     {
         $columns['institution'] = ['institution', false];
         return $columns;
     }
 
-    public function addInstitutionOrderbySpec(array $map, object $table): array
+    public function addInstitutionOrderBySpec(array $map): array
     {
         global $wpdb;
 
@@ -51,7 +41,7 @@ class ContentCheckerBooksScanTable
         return $map;
     }
 
-    public function augmentBooksScanQuery($query, array $request, object $table)
+    public function augmentBooksScanQuery($query)
     {
         global $wpdb;
         $institutionId = get_institution_by_manager();

--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -50,7 +50,7 @@ function get_institution_books(): array
 function get_allowed_pages(): array
 {
     $pagesAllowed = [
-        'admin.php' => ['pb_network_analytics_booklist', 'pb_network_analytics_userlist', 'pb_network_analytics_admin', 'pb_cloner','delete','pb_lti_stats'],
+        'admin.php' => ['pb_network_analytics_booklist', 'pb_network_analytics_userlist', 'pb_network_analytics_admin', 'pb_cloner','delete','pb_lti_stats', 'pb_book_scan'],
         'sites.php' => ['confirm', 'delete', 'pb_network_analytics_booklist', 'pb_network_analytics_userlist', 'pb_network_analytics_admin', 'pb_cloner','activateblog','deactivateblog', 'deleteblog'],
         'index.php' => ['', 'book_dashboard', 'pb_institutional_manager', 'pb_home_page', 'pb_catalog','pb_network_page'],
         'tools.php',


### PR DESCRIPTION
Issue: https://github.com/pressbooks/pressbooks-content-checker/issues/44

PR that uses these hooks: https://github.com/pressbooks/pressbooks-content-checker/pull/53

This pull request introduces an integration that adds institutional data to the Content Checker Books Scan Table, enhancing the reporting and filtering capabilities for multi-institution environments. The changes primarily focus on injecting an "Institution" column into the scan table, making it sortable, and ensuring queries are properly joined to institution data. Additionally, access to the book scan page is updated for institutional managers.

Enhancements to Content Checker Books Scan Table:

* Added new class `ContentCheckerBooksScanTable` to inject an "Institution" column, make it sortable, and augment queries to join institution data in the Content Checker Books Scan Table.
* Registered `ContentCheckerBooksScanTable` integration in the application bootstrap to activate these enhancements during setup. [[1]](diffhunk://#diff-a0a50eeca13c428c300657c036becaf0437f262681f86bb8d219512fd04ba817R12) [[2]](diffhunk://#diff-a0a50eeca13c428c300657c036becaf0437f262681f86bb8d219512fd04ba817R50-R51)

Access control improvements:

* Updated `get_allowed_pages()` to include `pb_book_scan` for institutional managers, ensuring proper access to the book scan page.

### Testing
- Activate content link checker plugin
- checkout to https://github.com/pressbooks/pressbooks-content-checker/pull/53 in the pressbooks link checker plugin
- Log in as a super admin and go to Books > Book Scanner
- You should see an **Institution** column in the table. 
- You should be able to sort the table by this column.
- Log in as a IM
- Go to Books > Book Scanner
- You should be able to see only the books with reports only from your institution