### PR TITLE
fix: join with blog table instead of checker reports one

### DIFF
--- a/src/Integrations/ContentCheckerBooksScanTable.php
+++ b/src/Integrations/ContentCheckerBooksScanTable.php
@@ -47,7 +47,7 @@ class ContentCheckerBooksScanTable
         $institutionId = get_institution_by_manager();
 
         return $query
-            ->leftJoin('institutions_blogs', 'institutions_blogs.blog_id', '=', 'pressbooks_content_checker_reports.blog_id')
+            ->leftJoin('institutions_blogs', 'institutions_blogs.blog_id', '=', 'blogs.blog_id')
             ->leftJoin('institutions', 'institutions.id', '=', 'institutions_blogs.institution_id')
             ->selectRaw('MAX(' . $wpdb->prefix . 'institutions.name) AS institution')
             ->when($institutionId !== 0, function ($q) use ($institutionId) {


### PR DESCRIPTION
See: https://github.com/pressbooks/pressbooks-content-checker/issues/61#issuecomment-3851906755

This pull request makes a targeted update to the join condition in the `augmentBooksScanQuery` method to ensure that the correct blog identifier is used when joining tables. This change improves the accuracy of data relationships in the query. This will display the institutions even if there's no checker report.

Database query correction:

* Updated the join condition in `augmentBooksScanQuery` to use `blogs.blog_id` instead of `pressbooks_content_checker_reports.blog_id` when joining the `institutions_blogs` table, ensuring proper association between blogs and institutions.