### PR TITLE
fix: improve table styles

### DIFF
--- a/resources/assets/styles/pressbooks-multi-institutions.css
+++ b/resources/assets/styles/pressbooks-multi-institutions.css
@@ -84,6 +84,24 @@ h1.institutions-totals-heading {
 		}
 	}
 
+	.assign-users {
+		.column-username {
+			min-width: 8rem;
+		}
+
+		.column-name {
+			min-width: 10rem;
+		}
+
+		.column-email {
+			min-width: 12rem;
+		}
+
+		.column-institution {
+			min-width: 8rem;
+		}
+	}
+
 	.wp-list-table td {
 		border-bottom: 1px solid var(--border-color);
 	}

--- a/resources/assets/styles/pressbooks-multi-institutions.css
+++ b/resources/assets/styles/pressbooks-multi-institutions.css
@@ -71,9 +71,16 @@ h1.institutions-totals-heading {
 #pressbooks-multi-institution-assign-table {
 	.assign-books {
 		.column-cover {
-			min-width: 50px;
+			width: 3rem;
+			min-width: 3rem;
 			text-align: center;
-			width: 5%;
+
+			img {
+				display: block;
+				margin: 0 auto;
+				max-width: 100%;
+				height: auto;
+			}
 		}
 	}
 

--- a/resources/views/assign/index.blade.php
+++ b/resources/views/assign/index.blade.php
@@ -60,6 +60,8 @@
 			</ul>
 		</div>
 
-		{!! $table->display() !!}
+		<div class="pb-list-table-responsive" style="--pb-list-table-min-width: {{ $table_min_width }}">
+			{!! $table->display() !!}
+		</div>
 	</form>
 </div>

--- a/resources/views/assign/index.blade.php
+++ b/resources/views/assign/index.blade.php
@@ -60,7 +60,7 @@
 			</ul>
 		</div>
 
-		<div class="pb-list-table-responsive" style="--pb-list-table-min-width: {{ $table_min_width }}">
+		<div class="pb-table-scroll-container" style="--pb-list-table-min-width: {{ $table_min_width }}">
 			{!! $table->display() !!}
 		</div>
 	</form>

--- a/src/Controllers/AssignBooksController.php
+++ b/src/Controllers/AssignBooksController.php
@@ -41,6 +41,7 @@ class AssignBooksController extends BaseController
                 ->toArray(),
             'result' => $result,
             'table' => $this->table,
+            'table_min_width' => '760px',
         ]);
     }
 

--- a/src/Controllers/AssignUsersController.php
+++ b/src/Controllers/AssignUsersController.php
@@ -40,6 +40,7 @@ class AssignUsersController extends BaseController
             'params' => collect($filters)
                 ->flatMap(fn (string $filter, string $key) => [$key => sanitize_text_field($_REQUEST[$key] ?? $filter)])
                 ->toArray(),
+            'table_min_width' => '600px',
         ]);
     }
 

--- a/src/Views/AssignBooksTable.php
+++ b/src/Views/AssignBooksTable.php
@@ -26,6 +26,11 @@ class AssignBooksTable extends WP_List_Table
         ]);
     }
 
+    protected function get_table_classes(): array
+    {
+        return ['widefat', 'striped', 'table-view-list', 'pb-table', $this->_args['plural']];
+    }
+
     public function get_columns(): array
     {
         return [

--- a/src/Views/AssignUsersTable.php
+++ b/src/Views/AssignUsersTable.php
@@ -20,6 +20,11 @@ class AssignUsersTable extends WP_List_Table
         ]);
     }
 
+    protected function get_table_classes(): array
+    {
+        return ['widefat', 'striped', 'table-view-list', 'pb-table', $this->_args['plural']];
+    }
+
     public function column_default($item, $column_name): string
     {
         return $item[$column_name] ?? '';


### PR DESCRIPTION
Improve the display and responsiveness of the assign books and assign users tables, using the principles established in core Pressbooks via https://github.com/pressbooks/pressbooks/pull/4358. Together with https://github.com/pressbooks/pressbooks-content-checker/pull/89 addresses https://github.com/pressbooks/pressbooks-content-checker/issues/56. 

**Table Styling and Responsiveness:**

* Add `pb-table-scroll-container` to wrap tables in `assign/index.blade.php`, allowing horizontal scrolling and enforcing minimum table widths using the new `table_min_width` variable. (`resources/views/assign/index.blade.php`, [[1]](diffhunk://#diff-2e7a9f3d0f3f13ad23ac0b135f1055662d41411e6e08f8a7b2c3db3183d594e9R44) [[2]](diffhunk://#diff-735e3296ccbdeff395725a606c7f767306590fd231a66c498f77856355fc2263R43) [[3]](diffhunk://#diff-bf0404d406d9b5f851d2efa5fc35c4144b2af498ea41a5de40e7c8272bc41e26R63-R65)
* Set widths and min-widths in `pressbooks-multi-institutions.css`. (`resources/assets/styles/pressbooks-multi-institutions.css`, [resources/assets/styles/pressbooks-multi-institutions.cssL74-R101](diffhunk://#diff-0d219c0f839b726aa2667e9110ffde0759fa3d912c94644e09f4dfceba3c52adL74-R101))