### PR TITLE
fix: unsigned migration

### DIFF
--- a/src/Database/Migrations/0002_create_institutions_blogs_table.php
+++ b/src/Database/Migrations/0002_create_institutions_blogs_table.php
@@ -13,9 +13,22 @@ return new class implements MigrationInterface {
         if ($schema->hasTable('institutions_blogs')) {
             return;
         }
-        $schema->create('institutions_blogs', function (Blueprint $table) {
+
+        $connection = app('db')->connection();
+        $prefix = $connection->getTablePrefix();
+        $blogsColumn = $connection->selectOne(
+            "SELECT COLUMN_TYPE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = 'blog_id'",
+            [$prefix . 'blogs']
+        );
+        $blogIdIsUnsigned = $blogsColumn && str_contains(strtolower($blogsColumn->COLUMN_TYPE), 'unsigned');
+
+        $schema->create('institutions_blogs', function (Blueprint $table) use ($blogIdIsUnsigned) {
             $table->id();
-            $table->unsignedBigInteger('blog_id');
+            if ($blogIdIsUnsigned) {
+                $table->unsignedBigInteger('blog_id');
+            } else {
+                $table->bigInteger('blog_id');
+            }
             $table->unsignedBigInteger('institution_id');
 
             $table->foreign('blog_id')

--- a/src/Database/Migrations/0005_alter_institutions_blogs_blog_id_column.php
+++ b/src/Database/Migrations/0005_alter_institutions_blogs_blog_id_column.php
@@ -14,8 +14,19 @@ return new class implements MigrationInterface {
         }
 
         $connection = app('db')->connection();
+        $prefix = $connection->getTablePrefix();
 
-        $table = $connection->getTablePrefix() . 'institutions_blogs';
+        // Only proceed if wp_blogs.blog_id is already unsigned (WP 6.9+).
+        $blogsColumn = $connection->selectOne(
+            "SELECT COLUMN_TYPE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = 'blog_id'",
+            [$prefix . 'blogs']
+        );
+
+        if (! $blogsColumn || ! str_contains(strtolower($blogsColumn->COLUMN_TYPE), 'unsigned')) {
+            return;
+        }
+
+        $table = $prefix . 'institutions_blogs';
 
         $column = $connection->selectOne(
             "SELECT COLUMN_TYPE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = 'blog_id'",
@@ -29,12 +40,12 @@ return new class implements MigrationInterface {
         $connection->statement("ALTER TABLE `{$table}` DROP FOREIGN KEY `institutions_blogs_blog_id_foreign`");
         $connection->statement("ALTER TABLE `{$table}` MODIFY `blog_id` BIGINT UNSIGNED NOT NULL");
         $connection->statement(
-            "ALTER TABLE `{$table}` ADD CONSTRAINT `institutions_blogs_blog_id_foreign` FOREIGN KEY (`blog_id`) REFERENCES `{$connection->getTablePrefix()}blogs` (`blog_id`) ON DELETE CASCADE"
+            "ALTER TABLE `{$table}` ADD CONSTRAINT `institutions_blogs_blog_id_foreign` FOREIGN KEY (`blog_id`) REFERENCES `{$prefix}blogs` (`blog_id`) ON DELETE CASCADE"
         );
     }
 
     public function down(): void
     {
-        // Intentionally left empty - no need to revert to signed bigint
+        // No need to revert, as the change is non-destructive and compatible with both signed and unsigned blog_id.
     }
 };


### PR DESCRIPTION
This pull request updates the database migrations related to the `institutions_blogs` table to ensure compatibility with changes in the `blogs` table, specifically regarding the signed/unsigned status of the `blog_id` column. The migrations now dynamically check the type of the `blog_id` column in the `blogs` table and adjust the creation and alteration of the `institutions_blogs` table accordingly, preventing schema conflicts and foreign key issues.

**Migration logic improvements for `institutions_blogs`:**

* The migration for creating the `institutions_blogs` table now checks whether the `blog_id` column in the `blogs` table is unsigned and creates the corresponding column as unsigned or signed to match, ensuring foreign key compatibility.

* The migration for altering the `institutions_blogs.blog_id` column now only attempts to convert it to unsigned if the referenced `blogs.blog_id` column is already unsigned, preventing foreign key constraint errors.

* The foreign key constraint in the alteration migration now consistently uses the correct table prefix for the `blogs` table, ensuring proper referencing in environments with custom prefixes.